### PR TITLE
feat: allow documents to prevent folder from unlocking and being edited

### DIFF
--- a/packages/sanity-studio/README.md
+++ b/packages/sanity-studio/README.md
@@ -160,6 +160,29 @@ export default defineType({
 });
 ```
 
+### Lock folder renaming
+
+By default, folders can be renamed. Set the `folder.canUnlock` option to `false` to disable this.
+
+```tsx
+import { definePathname } from "@tinloof/sanity-studio";
+
+export default defineType({
+  type: "document",
+  name: "modularPage",
+  fields: [
+    definePathname({
+      name: "pathname",
+      options: {
+        folder: {
+          canUnlock: false,
+        },
+      },
+    }),
+  ],
+});
+```
+
 ### Customizing pages previews
 
 Documents can have their preview customized on the pages navigator using the [List Previews API](https://www.sanity.io/docs/previews-list-views):

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -1,4 +1,4 @@
-import { EditIcon, EyeOpenIcon, FolderIcon } from "@sanity/icons";
+import { LockIcon, EditIcon, EyeOpenIcon, FolderIcon } from "@sanity/icons";
 import {
   usePresentationNavigate,
   usePresentationParams,
@@ -31,11 +31,10 @@ const FolderText = styled(Text)`
   }
 `;
 
-export function PathnameFieldComponent(
-  props: ObjectFieldProps<SlugValue>
-): JSX.Element {
-  const i18nOptions = (props.schemaType.options as PathnameOptions | undefined)
-    ?.i18n ?? { enabled: false, defaultLocaleId: undefined };
+export function PathnameFieldComponent(props: ObjectFieldProps<SlugValue>) {
+  const fieldOptions = props.schemaType.options as PathnameOptions | undefined;
+  const folderOptions = fieldOptions?.folder ?? { canUnlock: true };
+  const i18nOptions = fieldOptions?.i18n ?? { enabled: false, defaultLocaleId: undefined };
   const document = useFormValue([]) as DocumentWithLocale;
   const {
     inputProps: { onChange, value, readOnly },
@@ -46,6 +45,7 @@ export function PathnameFieldComponent(
   const folder = segments?.slice(0, -1).join("/");
   const slug = segments?.slice(-1)[0] || "";
   const [folderLocked, setFolderLocked] = useState(!!folder);
+  const folderCanUnlock = !readOnly && folderOptions.canUnlock;
 
   const fullPathInputRef = useRef<HTMLInputElement>(null);
   const pathSegmentInputRef = useRef<HTMLInputElement>(null);
@@ -114,14 +114,14 @@ export function PathnameFieldComponent(
               </Text>
               <FolderText muted>{folder}</FolderText>
               <UnlockButton
-                icon={EditIcon}
+                icon={folderCanUnlock ? EditIcon : LockIcon}
                 onClick={unlockFolder}
-                title="Edit path's folder"
+                title={folderCanUnlock ? "Edit path's folder" : "Folder is locked and cannot be changed"}
                 mode="bleed"
                 tone="primary"
                 padding={2}
                 fontSize={1}
-                disabled={readOnly}
+                disabled={!folderCanUnlock}
               >
                 <span />
               </UnlockButton>

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -1,4 +1,4 @@
-import { LockIcon, EditIcon, EyeOpenIcon, FolderIcon } from "@sanity/icons";
+import { EditIcon, EyeOpenIcon, FolderIcon, LockIcon } from "@sanity/icons";
 import {
   usePresentationNavigate,
   usePresentationParams,
@@ -31,10 +31,15 @@ const FolderText = styled(Text)`
   }
 `;
 
-export function PathnameFieldComponent(props: ObjectFieldProps<SlugValue>) {
+export function PathnameFieldComponent(
+  props: ObjectFieldProps<SlugValue>
+): JSX.Element {
   const fieldOptions = props.schemaType.options as PathnameOptions | undefined;
   const folderOptions = fieldOptions?.folder ?? { canUnlock: true };
-  const i18nOptions = fieldOptions?.i18n ?? { enabled: false, defaultLocaleId: undefined };
+  const i18nOptions = fieldOptions?.i18n ?? {
+    enabled: false,
+    defaultLocaleId: undefined,
+  };
   const document = useFormValue([]) as DocumentWithLocale;
   const {
     inputProps: { onChange, value, readOnly },
@@ -116,7 +121,11 @@ export function PathnameFieldComponent(props: ObjectFieldProps<SlugValue>) {
               <UnlockButton
                 icon={folderCanUnlock ? EditIcon : LockIcon}
                 onClick={unlockFolder}
-                title={folderCanUnlock ? "Edit path's folder" : "Folder is locked and cannot be changed"}
+                title={
+                  folderCanUnlock
+                    ? "Edit path's folder"
+                    : "Folder is locked and cannot be changed"
+                }
                 mode="bleed"
                 tone="primary"
                 padding={2}
@@ -171,6 +180,7 @@ export function PathnameFieldComponent(props: ObjectFieldProps<SlugValue>) {
     handleBlur,
     value,
     localizedPathname,
+    folderCanUnlock,
   ]);
 
   return (

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -158,6 +158,9 @@ export type SectionAddHandler = (params: {
 }) => void;
 
 export type PathnameOptions = SlugOptions & {
+  folder?: {
+    canUnlock?: boolean;
+  };
   i18n?: {
     enabled?: boolean;
     defaultLocaleId?: string;


### PR DESCRIPTION
This PR adds the option to `pathname` fields to prevent folders from being unlocked and edited per document type.

This is useful for documents that are initialised with a particular directory, such as Products, Factsheets, Blog articles, etc, where we don't want to allow the parent folder to be changed.

## Overview

This PR makes use of the existing `options` object on the pathname schema definition. It adds a new `folder` key, which takes an object with key/value `canUnlock: boolean`. This will initialise to `true` if not set in the document schema.

```
definePathname({ name: 'pathname', options: { folder: { canUnlock: false } } }),
```

When `false`, the field is set to `disabled`, a padlock icon replaces the pencil icon, and the title is changed to explain that it is locked and cannot be changed. The slug component still allows the last part of the slug to be edited.

## Screenshots
<img width="707" alt="image" src="https://github.com/tinloof/sanity-kit/assets/2754728/7ae27091-685f-417a-81f9-fdebc175deff">
