### PR TITLE
fix: add `repository` field to `package.json`

### DIFF
--- a/packages/sanity-studio/package.json
+++ b/packages/sanity-studio/package.json
@@ -6,6 +6,11 @@
     "sanity",
     "sanity-plugin"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/tinloof/sanity-kit.git",
+    "directory": "packages/sanity-studio"
+  },
   "license": "MIT",
   "type": "module",
   "author": "Tinloof",

--- a/packages/sanity-web/package.json
+++ b/packages/sanity-web/package.json
@@ -2,6 +2,11 @@
   "name": "@tinloof/sanity-web",
   "version": "0.2.1",
   "description": "Sanity-related utilities for web development",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/tinloof/sanity-kit.git",
+    "directory": "packages/sanity-web"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.mjs",


### PR DESCRIPTION
Heya 👋 

We've setup your `@tinloof/sanity-kit` over at https://github.com/sanity-io/visual-editing/tree/main/apps/next-with-i18n to ensure that we don't accidentally introduce breaking changes to how you customize `@sanity/presentation` :) 
That's how we noticed that when `renovatebot` created a [PR bumping your package](https://github.com/sanity-io/visual-editing/pull/1415) it didn't succeed in grabbing your changelogs.
In this PR I'm adding the metadata fields needed for tools like `renovatebot`, `dependabot` and such to find your release notes 🙇 

Great work on your kit btw, we're huge fans 💖 