### PR TITLE
Fix definePathname inititalValue in pagesNavigator

### DIFF
--- a/.changeset/rare-hairs-prove.md
+++ b/.changeset/rare-hairs-prove.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": patch
+---
+
+Fix: `definePathname` initialValue is now used when creating new documents from the pages navigator.

--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
           enable: 'http://localhost:9999/api/draft',
         },
       },
-      creatablePages: ['page'],
+      creatablePages: ['page', 'post', 'author'],
     }),
     visionTool(),
   ],

--- a/apps/studio/schemas/author.ts
+++ b/apps/studio/schemas/author.ts
@@ -3,19 +3,18 @@ import {defineType} from 'sanity'
 
 export default defineType({
   type: 'document',
-  name: 'page',
+  name: 'author',
   fields: [
     {
       type: 'string',
       name: 'title',
     },
-    {
-      type: 'image',
-      name: 'image',
-      options: {
-        hotspot: true,
+    definePathname({
+      name: 'pathname',
+      initialValue: {
+        current: '/authors/',
       },
-    },
-    definePathname({name: 'pathname'}),
+      options: {folder: {canUnlock: false}},
+    }),
   ],
 })

--- a/apps/studio/schemas/index.ts
+++ b/apps/studio/schemas/index.ts
@@ -1,3 +1,5 @@
+import author from './author'
 import page from './page'
+import post from './post'
 
-export const schemaTypes = [page]
+export const schemaTypes = [page, post, author]

--- a/apps/studio/schemas/post.ts
+++ b/apps/studio/schemas/post.ts
@@ -3,19 +3,18 @@ import {defineType} from 'sanity'
 
 export default defineType({
   type: 'document',
-  name: 'page',
+  name: 'post',
   fields: [
     {
       type: 'string',
       name: 'title',
     },
-    {
-      type: 'image',
-      name: 'image',
-      options: {
-        hotspot: true,
+    definePathname({
+      name: 'pathname',
+      initialValue: {
+        current: '/blog/',
       },
-    },
-    definePathname({name: 'pathname'}),
+      options: {folder: {canUnlock: false}},
+    }),
   ],
 })

--- a/packages/sanity-studio/src/plugins/navigator/components/Header.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/Header.tsx
@@ -158,7 +158,7 @@ function getPathname({
     return initialValue;
   }
 
-  return "";
+  return "/";
 }
 
 function resolveTitle(currentDir: string) {

--- a/packages/sanity-studio/src/plugins/navigator/components/Header.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/Header.tsx
@@ -5,30 +5,30 @@ import {
   Flex,
   Menu,
   MenuButton,
-  MenuItem,
+  MenuItem as MenuItemComponent,
   Text,
 } from "@sanity/ui";
-import React from "react";
-
-import { HeaderProps } from "../../../types";
-import { useNavigator } from "../context";
-
+import { useCallback } from "react";
+import { useSchema } from "sanity";
 import { useIntentLink } from "sanity/router";
+
+import { HeaderProps, NormalizedCreatablePage } from "../../../types";
+import { useNavigator } from "../context";
 import { getTemplateName, pathnameToTitle } from "../utils";
 import TooltipWrapper from "./ToolTipWrapper";
 
-const Header = ({ pages, domRef, children }: HeaderProps) => {
+const Header = ({ pages, domRef, children }: HeaderProps): JSX.Element => {
   const { currentDir, setCurrentDir, locale } = useNavigator();
 
-  const back = () => {
+  const back = useCallback(() => {
     if (currentDir) {
       setCurrentDir(currentDir.split("/").slice(0, -1).join("/") || "");
     }
-  };
+  }, [currentDir, setCurrentDir]);
 
-  const backToRoot = () => {
+  const backToRoot = useCallback(() => {
     setCurrentDir("");
-  };
+  }, [setCurrentDir]);
 
   return (
     <>
@@ -78,24 +78,11 @@ const Header = ({ pages, domRef, children }: HeaderProps) => {
                   <Menu>
                     {pages?.map(({ type, title }) => (
                       <MenuItem
+                        page={{ type, title }}
+                        locale={locale}
+                        currentDir={currentDir}
                         key={type}
-                        {...useIntentLink({
-                          intent: "create",
-                          params: [
-                            {
-                              type,
-                              template: getTemplateName(type),
-                            },
-                            {
-                              pathname: `${currentDir}/`,
-                              locale,
-                            },
-                          ],
-                        })}
-                        as="a"
-                      >
-                        <Text size={1}>{title}</Text>
-                      </MenuItem>
+                      />
                     ))}
                   </Menu>
                 }
@@ -114,6 +101,65 @@ const Header = ({ pages, domRef, children }: HeaderProps) => {
 Header.displayName = "Header";
 
 export default Header;
+
+function MenuItem(props: {
+  locale: string | undefined;
+  currentDir: string;
+  page: NormalizedCreatablePage;
+}) {
+  const { locale, currentDir, page } = props;
+  const { type, title } = page;
+  const schema = useSchema();
+  const schemaType = schema.get(type);
+  const pathnameField =
+    schemaType?.jsonType === "object"
+      ? schemaType.fields.find((field) => field.name === "pathname")
+      : null;
+  const pathnameCurrentInitialValue: string | undefined =
+    pathnameField?.type.initialValue?.current;
+
+  return (
+    <MenuItemComponent
+      {...useIntentLink({
+        intent: "create",
+        params: [
+          {
+            type,
+            template: getTemplateName(type),
+          },
+          {
+            pathname: getPathname({
+              currentDir,
+              initialValue: pathnameCurrentInitialValue,
+            }),
+            locale,
+          },
+        ],
+      })}
+      as="a"
+    >
+      <Text size={1}>{title}</Text>
+    </MenuItemComponent>
+  );
+}
+
+function getPathname({
+  currentDir,
+  initialValue,
+}: {
+  currentDir: string;
+  initialValue: string | undefined;
+}) {
+  if (currentDir) {
+    return `${currentDir}/`;
+  }
+
+  if (initialValue) {
+    return initialValue;
+  }
+
+  return "";
+}
 
 function resolveTitle(currentDir: string) {
   if (!currentDir) {


### PR DESCRIPTION
This PR fixes https://github.com/tinloof/sanity-kit/issues/22.

`definePathname` initialValue is now used when creating a new document from the root of the pages navigator.

This also seems to fix https://github.com/tinloof/sanity-kit/issues/36 based on my tests. The initialValue is now used on document creation so the `canUnlock` option works as expected.