### PR TITLE
Add validation UI to input

### DIFF
--- a/.changeset/blue-numbers-beam.md
+++ b/.changeset/blue-numbers-beam.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": patch
+---
+
+Add validation UI to input. Thanks @tamaccount.

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -6,7 +6,14 @@ import {
 import { Box, Button, Card, Flex, Stack, Text, TextInput } from "@sanity/ui";
 import { getDocumentPath, stringToPathname } from "@tinloof/sanity-web";
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { ObjectFieldProps, set, SlugValue, unset, useFormValue, FormFieldValidationStatus } from "sanity";
+import {
+  FormFieldValidationStatus,
+  ObjectFieldProps,
+  set,
+  SlugValue,
+  unset,
+  useFormValue,
+} from "sanity";
 import { styled } from "styled-components";
 
 import { DocumentWithLocale, PathnameOptions } from "../types";
@@ -56,9 +63,15 @@ export function PathnameFieldComponent(
   const fullPathInputRef = useRef<HTMLInputElement>(null);
   const pathSegmentInputRef = useRef<HTMLInputElement>(null);
 
-  const inputValidationProps = validation.length ? {
-    customValidity: validation[0].message,
-  } : {};
+  const inputValidationProps = useMemo(
+    () =>
+      validation.length
+        ? {
+            customValidity: validation[0].message,
+          }
+        : {},
+    [validation]
+  );
 
   const updateFinalSegment = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
@@ -186,6 +199,7 @@ export function PathnameFieldComponent(
     updateFinalSegment,
     handleBlur,
     value,
+    inputValidationProps,
     localizedPathname,
     folderCanUnlock,
   ]);
@@ -199,7 +213,11 @@ export function PathnameFieldComponent(
           </Text>
           {validation.length > 0 && (
             <Box marginLeft={2}>
-              <FormFieldValidationStatus fontSize={1} placement="top" validation={validation} />
+              <FormFieldValidationStatus
+                fontSize={1}
+                placement="top"
+                validation={validation}
+              />
             </Box>
           )}
         </Flex>

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -6,7 +6,7 @@ import {
 import { Box, Button, Card, Flex, Stack, Text, TextInput } from "@sanity/ui";
 import { getDocumentPath, stringToPathname } from "@tinloof/sanity-web";
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import { ObjectFieldProps, set, SlugValue, unset, useFormValue } from "sanity";
+import { ObjectFieldProps, set, SlugValue, unset, useFormValue, FormFieldValidationStatus } from "sanity";
 import { styled } from "styled-components";
 
 import { DocumentWithLocale, PathnameOptions } from "../types";
@@ -45,6 +45,7 @@ export function PathnameFieldComponent(
     inputProps: { onChange, value, readOnly },
     title,
     description,
+    validation = [],
   } = props;
   const segments = value?.current?.split("/").slice(0);
   const folder = segments?.slice(0, -1).join("/");
@@ -54,6 +55,10 @@ export function PathnameFieldComponent(
 
   const fullPathInputRef = useRef<HTMLInputElement>(null);
   const pathSegmentInputRef = useRef<HTMLInputElement>(null);
+
+  const inputValidationProps = validation.length ? {
+    customValidity: validation[0].message,
+  } : {};
 
   const updateFinalSegment = useCallback(
     (e: React.FormEvent<HTMLInputElement>) => {
@@ -146,6 +151,7 @@ export function PathnameFieldComponent(
               ref={pathSegmentInputRef}
               onBlur={handleBlur}
               disabled={readOnly}
+              {...inputValidationProps}
             />
           </Box>
           <PreviewButton localizedPathname={localizedPathname || ""} />
@@ -164,6 +170,7 @@ export function PathnameFieldComponent(
             onBlur={handleBlur}
             disabled={readOnly}
             style={{ flex: 1 }}
+            {...inputValidationProps}
           />
         </Box>
         <PreviewButton localizedPathname={localizedPathname || ""} />
@@ -186,9 +193,16 @@ export function PathnameFieldComponent(
   return (
     <Stack space={3}>
       <Stack space={2} flex={1}>
-        <Text size={1} weight="semibold">
-          {title}
-        </Text>
+        <Flex align="center" paddingY={1}>
+          <Text size={1} weight="semibold">
+            {title}
+          </Text>
+          {validation.length > 0 && (
+            <Box marginLeft={2}>
+              <FormFieldValidationStatus fontSize={1} placement="top" validation={validation} />
+            </Box>
+          )}
+        </Flex>
         {description && <Text size={1}>{description}</Text>}
       </Stack>
 


### PR DESCRIPTION
https://github.com/tinloof/sanity-kit/assets/15708264/7a70928c-4c15-455a-81fc-023f05c0c4ff

now, `validation` will show in the pathname input in sanity studio
```
definePathname({
    name: "pathname",
    initialValue: {
      current: '/blog/',
    },
    options: {
      folder: {
        canUnlock: false,
      },
      i18n: {
        enabled: true,
        defaultLocaleId: config.i18n.defaultLocaleId,
      },
    },
    validation: rule => rule.custom((pathname) => {
      return !!pathname?.current?.replace('/blog/', '').length || "Required";
    }),
  })
```