### PR TITLE
feat: allow pathname field to specify prefix

### DIFF
--- a/.changeset/tiny-phones-fly.md
+++ b/.changeset/tiny-phones-fly.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": minor
+---
+
+Add prefix option to definePathname. Thanks @Jamiewarb!

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -16,7 +16,8 @@ import {
 } from "sanity";
 import { styled } from "styled-components";
 
-import { DocumentWithLocale, PathnameOptions } from "../types";
+import { DocumentWithLocale, PathnameInputProps, PathnameOptions } from '../types';
+import { usePathnamePrefix } from '../hooks/usePathnamePrefix';
 
 const UnlockButton = styled(Button)`
   position: static !important;
@@ -38,11 +39,9 @@ const FolderText = styled(Text)`
   }
 `;
 
-export function PathnameFieldComponent(
-  props: ObjectFieldProps<SlugValue>
-): JSX.Element {
+export function PathnameFieldComponent(props: PathnameInputProps): JSX.Element {
   const fieldOptions = props.schemaType.options as PathnameOptions | undefined;
-  const prefix = fieldOptions?.prefix ?? window.location.origin;
+  const { prefix } = usePathnamePrefix(props);
   const folderOptions = fieldOptions?.folder ?? { canUnlock: true };
   const i18nOptions = fieldOptions?.i18n ?? {
     enabled: false,

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -42,6 +42,7 @@ export function PathnameFieldComponent(
   props: ObjectFieldProps<SlugValue>
 ): JSX.Element {
   const fieldOptions = props.schemaType.options as PathnameOptions | undefined;
+  const prefix = fieldOptions?.prefix ?? window.location.origin;
   const folderOptions = fieldOptions?.folder ?? { canUnlock: true };
   const i18nOptions = fieldOptions?.i18n ?? {
     enabled: false,
@@ -226,7 +227,7 @@ export function PathnameFieldComponent(
 
       {typeof value?.current === "string" && (
         <Text muted>
-          {window.location.origin}
+          {prefix}
           {localizedPathname}
         </Text>
       )}

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -6,18 +6,15 @@ import {
 import { Box, Button, Card, Flex, Stack, Text, TextInput } from "@sanity/ui";
 import { getDocumentPath, stringToPathname } from "@tinloof/sanity-web";
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import {
-  FormFieldValidationStatus,
-  ObjectFieldProps,
-  set,
-  SlugValue,
-  unset,
-  useFormValue,
-} from "sanity";
+import { FormFieldValidationStatus, set, unset, useFormValue } from "sanity";
 import { styled } from "styled-components";
 
-import { DocumentWithLocale, PathnameInputProps, PathnameOptions } from '../types';
-import { usePathnamePrefix } from '../hooks/usePathnamePrefix';
+import { usePathnamePrefix } from "../hooks/usePathnamePrefix";
+import {
+  DocumentWithLocale,
+  PathnameInputProps,
+  PathnameOptions,
+} from "../types";
 
 const UnlockButton = styled(Button)`
   position: static !important;

--- a/packages/sanity-studio/src/hooks/usePathnameContext.ts
+++ b/packages/sanity-studio/src/hooks/usePathnameContext.ts
@@ -1,0 +1,34 @@
+/**
+ * Provides the context needed for usePrefixLogic.
+ * Adapted from: https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/core/form/inputs/Slug/utils/useSlugContext.ts
+ */
+
+import { useMemo } from 'react'
+import {
+  useCurrentUser,
+  useDataset,
+  useProjectId,
+  useSchema,
+  SlugSourceContext,
+  useClient,
+} from 'sanity';
+
+export type SlugContext = Omit<SlugSourceContext, 'parent' | 'parentPath'>
+
+export function usePathnameContext(): SlugContext {
+  const client = useClient({apiVersion: '2024-05-14'})
+  const schema = useSchema()
+  const currentUser = useCurrentUser()
+  const projectId = useProjectId()
+  const dataset = useDataset()
+
+  return useMemo(() => {
+    return {
+      getClient: () => client,
+      projectId,
+      dataset,
+      schema,
+      currentUser,
+    }
+  }, [client, schema, currentUser, projectId, dataset])
+}

--- a/packages/sanity-studio/src/hooks/usePathnameContext.ts
+++ b/packages/sanity-studio/src/hooks/usePathnameContext.ts
@@ -3,24 +3,24 @@
  * Adapted from: https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/core/form/inputs/Slug/utils/useSlugContext.ts
  */
 
-import { useMemo } from 'react'
+import { useMemo } from "react";
 import {
+  SlugSourceContext,
+  useClient,
   useCurrentUser,
   useDataset,
   useProjectId,
   useSchema,
-  SlugSourceContext,
-  useClient,
-} from 'sanity';
+} from "sanity";
 
-export type SlugContext = Omit<SlugSourceContext, 'parent' | 'parentPath'>
+export type SlugContext = Omit<SlugSourceContext, "parent" | "parentPath">;
 
 export function usePathnameContext(): SlugContext {
-  const client = useClient({apiVersion: '2024-05-14'})
-  const schema = useSchema()
-  const currentUser = useCurrentUser()
-  const projectId = useProjectId()
-  const dataset = useDataset()
+  const client = useClient({ apiVersion: "2024-05-14" });
+  const schema = useSchema();
+  const currentUser = useCurrentUser();
+  const projectId = useProjectId();
+  const dataset = useDataset();
 
   return useMemo(() => {
     return {
@@ -29,6 +29,6 @@ export function usePathnameContext(): SlugContext {
       dataset,
       schema,
       currentUser,
-    }
-  }, [client, schema, currentUser, projectId, dataset])
+    };
+  }, [client, schema, currentUser, projectId, dataset]);
 }

--- a/packages/sanity-studio/src/hooks/usePathnamePrefix.ts
+++ b/packages/sanity-studio/src/hooks/usePathnamePrefix.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
-import { SanityDocument, useFormValue } from 'sanity';
-import { usePathnameContext } from './usePathnameContext';
-import { PathnameInputProps, PathnamePrefix } from '../types';
+import { useCallback, useEffect, useState } from "react";
+import { SanityDocument, useFormValue } from "sanity";
+
+import { PathnameInputProps, PathnamePrefix } from "../types";
+import { usePathnameContext } from "./usePathnameContext";
 
 /**
  * Returns the prefix specified on this pathname field, via options.prefix.
@@ -11,7 +12,9 @@ export function usePathnamePrefix(props: PathnameInputProps) {
   const sourceContext = usePathnameContext();
   const document = useFormValue([]) as SanityDocument | undefined;
 
-  const optionsPrefix = props.schemaType.options?.prefix as PathnamePrefix | undefined;
+  const optionsPrefix = props.schemaType.options?.prefix as
+    | PathnamePrefix
+    | undefined;
 
   const [urlPrefix, setUrlPrefix] = useState<string | undefined>();
 
@@ -19,25 +22,30 @@ export function usePathnamePrefix(props: PathnameInputProps) {
     async (doc: SanityDocument | undefined) => {
       if (!doc) return;
 
-      if (typeof optionsPrefix === 'string') {
+      if (typeof optionsPrefix === "string") {
         setUrlPrefix(optionsPrefix);
         return;
       }
 
-      if (typeof optionsPrefix === 'function') {
+      if (typeof optionsPrefix === "function") {
         try {
-          const value = await Promise.resolve(optionsPrefix(doc, sourceContext));
+          const value = await Promise.resolve(
+            optionsPrefix(doc, sourceContext)
+          );
           setUrlPrefix(value);
           return;
         } catch (error) {
-          console.error(`[prefixed-slug] Couldn't generate URL prefix: `, error);
+          console.error(
+            `[prefixed-slug] Couldn't generate URL prefix: `,
+            error
+          );
         }
       }
 
       // If it's not a string or a function, then we'll set prefix to undefined to avoid errors.
       setUrlPrefix(undefined);
     },
-    [setUrlPrefix, optionsPrefix],
+    [setUrlPrefix, optionsPrefix, sourceContext]
   );
 
   // Re-create the prefix whenever the document changes

--- a/packages/sanity-studio/src/hooks/usePathnamePrefix.ts
+++ b/packages/sanity-studio/src/hooks/usePathnamePrefix.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from 'react';
+import { SanityDocument, useFormValue } from 'sanity';
+import { usePathnameContext } from './usePathnameContext';
+import { PathnameInputProps, PathnamePrefix } from '../types';
+
+/**
+ * Returns the prefix specified on this pathname field, via options.prefix.
+ * It can be a string, a function or a promise, and should resolve to a string.
+ */
+export function usePathnamePrefix(props: PathnameInputProps) {
+  const sourceContext = usePathnameContext();
+  const document = useFormValue([]) as SanityDocument | undefined;
+
+  const optionsPrefix = props.schemaType.options?.prefix as PathnamePrefix | undefined;
+
+  const [urlPrefix, setUrlPrefix] = useState<string | undefined>();
+
+  const getUrlPrefix = useCallback(
+    async (doc: SanityDocument | undefined) => {
+      if (!doc) return;
+
+      if (typeof optionsPrefix === 'string') {
+        setUrlPrefix(optionsPrefix);
+        return;
+      }
+
+      if (typeof optionsPrefix === 'function') {
+        try {
+          const value = await Promise.resolve(optionsPrefix(doc, sourceContext));
+          setUrlPrefix(value);
+          return;
+        } catch (error) {
+          console.error(`[prefixed-slug] Couldn't generate URL prefix: `, error);
+        }
+      }
+
+      // If it's not a string or a function, then we'll set prefix to undefined to avoid errors.
+      setUrlPrefix(undefined);
+    },
+    [setUrlPrefix, optionsPrefix],
+  );
+
+  // Re-create the prefix whenever the document changes
+  useEffect(() => {
+    getUrlPrefix(document);
+  }, [document, getUrlPrefix]);
+
+  return {
+    prefix: urlPrefix,
+  };
+}

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -12,6 +12,7 @@ import {
   SlugOptions,
 } from "sanity";
 import { ObjectFieldProps, SlugValue } from "sanity";
+
 import { SlugContext } from "./hooks/usePathnameContext";
 
 export type NormalizedCreatablePage = {
@@ -159,7 +160,9 @@ export type SectionAddHandler = (params: {
   initialValue?: any;
 }) => void;
 
-export type PathnamePrefix = string | ((doc: SanityDocument, context: SlugContext) => Promise<string> | string);
+export type PathnamePrefix =
+  | string
+  | ((doc: SanityDocument, context: SlugContext) => Promise<string> | string);
 
 export type PathnameOptions = SlugOptions & {
   prefix?: PathnamePrefix;
@@ -180,4 +183,6 @@ export type PathnameParams = Omit<
   options?: PathnameOptions;
 };
 
-export type PathnameInputProps = ObjectFieldProps<SlugValue> & { schemaType: { options?: PathnameOptions } };
+export type PathnameInputProps = ObjectFieldProps<SlugValue> & {
+  schemaType: { options?: PathnameOptions };
+};

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -174,7 +174,7 @@ export type PathnameOptions = SlugOptions & {
 
 export type PathnameParams = Omit<
   SlugDefinition,
-  'type' | 'options' | 'name'
+  "type" | "options" | "name"
 > & {
   name?: string;
   options?: PathnameOptions;

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -158,6 +158,7 @@ export type SectionAddHandler = (params: {
 }) => void;
 
 export type PathnameOptions = SlugOptions & {
+  prefix?: string;
   folder?: {
     canUnlock?: boolean;
   };

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -11,6 +11,8 @@ import {
   SlugDefinition,
   SlugOptions,
 } from "sanity";
+import { ObjectFieldProps, SlugValue } from "sanity";
+import { SlugContext } from "./hooks/usePathnameContext";
 
 export type NormalizedCreatablePage = {
   title: string;
@@ -157,8 +159,10 @@ export type SectionAddHandler = (params: {
   initialValue?: any;
 }) => void;
 
+export type PathnamePrefix = string | ((doc: SanityDocument, context: SlugContext) => Promise<string> | string);
+
 export type PathnameOptions = SlugOptions & {
-  prefix?: string;
+  prefix?: PathnamePrefix;
   folder?: {
     canUnlock?: boolean;
   };
@@ -170,8 +174,10 @@ export type PathnameOptions = SlugOptions & {
 
 export type PathnameParams = Omit<
   SlugDefinition,
-  "type" | "options" | "name"
+  'type' | 'options' | 'name'
 > & {
   name?: string;
   options?: PathnameOptions;
 };
+
+export type PathnameInputProps = ObjectFieldProps<SlugValue> & { schemaType: { options?: PathnameOptions } };


### PR DESCRIPTION
# Context
The pathname field always shows the current hostname origin as the prefix, e.g. `localhost:3333`

However, some websites are hosted on separate subdomains, or need different prefixes based on document types or values.

# Overview
This PR adds the ability to specify the prefix in the pathname field definition, using `options.prefix`.

```js
definePathname({
  name: 'pathname', 
  options: { prefix: 'https://google.com' },
}),
```

It can also be defined as a function that returns a `string` or a `Promise<string>`. This function will receive the current document as well as the studio context as parameters:

```js
definePathname({
  name: 'pathname', 
  options: { prefix: (document, context) => 'https://google.com' },
}),
```

The context includes a client, project ID, dataset, schema and the currentUser

To maintain backwards compatibility, this value continues using `window.location.origin` if no prefix is defined for a pathname field.

<img width="656" alt="image" src="https://github.com/tinloof/sanity-kit/assets/2754728/3d5d933a-b28c-4f85-b2f2-7e58f64531ae">

<img width="653" alt="image" src="https://github.com/tinloof/sanity-kit/assets/2754728/b952e504-e53b-4da6-9db0-c4445a6c0d80">