### PR TITLE
Fix PreviewMedia component crashing when media is an object

### DIFF
--- a/packages/sanity-studio/src/plugins/navigator/components/Preview.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/Preview.tsx
@@ -193,6 +193,10 @@ const PreviewMedia = (props: SanityDefaultPreviewProps): React.ReactElement => {
     return <>{media}</>;
   }
 
+  if (typeof media === "object" && React.isValidElement(media)) {
+    return media;
+  }
+
   const Media = media as React.ComponentType<any>;
 
   return <Media />;


### PR DESCRIPTION
I was getting the following error when trying to access some of my pages inside folders:

```js
Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.

Check the render method of `PreviewMedia`.
Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.

Check the render method of `PreviewMedia`.
    at createFiberFromTypeAndProps (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:28366:17)
    at createFiberFromElement (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:28392:15)
    at reconcileSingleElement (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:10500:23)
    at reconcileChildFibersImpl (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:10564:35)
    at reconcileChildFibers (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:10634:27)
    at reconcileChildren (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:16108:28)
    at updateFunctionComponent (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:16623:3)
    at beginWork$1 (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:18790:16)
    at beginWork (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:27349:14)
    at performUnitOfWork (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:26089:12)
    at workLoopSync (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:25805:5)
    at renderRootSync (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:25760:7)
    at recoverFromConcurrentError (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:24934:20)
    at performSyncWorkOnRoot (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:25236:20)
    at flushSyncWorkAcrossRoots_impl (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:7791:13)
    at flushSyncWorkOnAllRoots (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:7751:3)
    at processRootScheduleInMicrotask (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:7896:3)
    at eval (webpack-internal:///(app-pages-browser)/./node_modules/.pnpm/next@14.2.3_@babel+core@7.24.5_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/compiled/react-dom-experimental/cjs/react-dom.development.js:8067:7)
```
I found that `PreviewMedia` wasn't handling cases where the `media` prop was a React object. Thus I fix this issue by directly returning the object if it is a valid ReactElement.

Before:

https://github.com/tinloof/sanity-kit/assets/13878860/7c352886-73bc-45ab-8a8b-62c068e62a8b

After:

https://github.com/tinloof/sanity-kit/assets/13878860/e18a00af-5227-41f8-96b8-08fc2d16f676

