### PR TITLE
fix(pathname): add back `window.location.origin` as default pathname prefix

### DIFF
--- a/packages/sanity-studio/src/hooks/usePathnamePrefix.ts
+++ b/packages/sanity-studio/src/hooks/usePathnamePrefix.ts
@@ -42,8 +42,7 @@ export function usePathnamePrefix(props: PathnameInputProps) {
         }
       }
 
-      // If it's not a string or a function, then we'll set prefix to undefined to avoid errors.
-      setUrlPrefix(undefined);
+      setUrlPrefix(window.location.origin);
     },
     [setUrlPrefix, optionsPrefix, sourceContext]
   );


### PR DESCRIPTION
Hey,

First of all, kudos on releasing this tool to the public, excellent stuff!

In #51, an option was added to set a custom prefix for the pathname field. This however removed the default prefix `window.location.origin`, which I believe was unintended since it still makes for a sensible default. This PR adds that back as the default.