### PR TITLE
feat: add requireLocale option to allow working with non-translatable page types even with i18n enabled

### DIFF
--- a/.changeset/slimy-keys-check.md
+++ b/.changeset/slimy-keys-check.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": minor
+---
+
+Add requireLocale option to allow working with non-translatable page types even with i18n enabled. Thanks @marcusforsberg!

--- a/packages/sanity-studio/README.md
+++ b/packages/sanity-studio/README.md
@@ -160,6 +160,23 @@ export default defineType({
 });
 ```
 
+#### Support documents without a locale
+
+By default, when internationalization is enabled, only pages whose `locale` field matches the currently selected locale will be shown in the list. If you have page types that are not translated but you still want them to show up in the list, you can set the `requireLocale` option to false in your `i18n` config:
+
+```ts
+const i18nConfig = {
+  locales: [
+    { id: "en", title: "English" },
+    { id: "fr", title: "French" },
+  ],
+  defaultLocaleId: "en",
+  requireLocale: false,
+};
+```
+
+Now all documents with a `pathname` field will show up in the list regardless of the filtered locale, even if they don't have a `locale` field (or their `locale` is `null`).
+
 ### Lock folder renaming
 
 By default, folders can be renamed. Set the `folder.canUnlock` option to `false` to disable this.

--- a/packages/sanity-studio/src/plugins/navigator/context/index.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/context/index.tsx
@@ -85,7 +85,11 @@ export const NavigatorProvider = ({
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const filteredData = i18nEnabled
-    ? data.filter((page) => page.locale === state.locale)
+    ? data.filter(
+        (page) =>
+          page.locale === state.locale ||
+          (!page.locale && i18n.requireLocale === false)
+      )
     : data;
 
   const rootTree = searchTree({

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -33,6 +33,7 @@ export type PagesNavigatorPluginOptions = PresentationPluginOptions & {
   i18n?: {
     locales: Locale[];
     defaultLocaleId?: string;
+    requireLocale?: boolean;
   };
   navigator?: Pick<PresentationNavigatorOptions, "maxWidth" | "minWidth">;
   creatablePages?: Array<NormalizedCreatablePage | string>;

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -24,6 +24,7 @@ export type PagesNavigatorOptions = {
   i18n?: {
     locales: Locale[];
     defaultLocaleId?: string;
+    requireLocale?: boolean;
   };
   creatablePages?: Array<NormalizedCreatablePage>;
 };


### PR DESCRIPTION
Here's a use case I don't necessarily know if you wish to support but that I hope you'll consider. 😊 

For our current project, we have a mix of localized and non-localized page types which we want to be able to access from the navigator. Since they all have a `pathname` field they automatically show up in the navigator, up until `i18n` is enabled at which point the list is filtered by the selected locale, causing the page types that don't have a `locale` field at all to disappear and become inaccessible. 

This PR adds a `requireLocale` option which can be set to `false` in order to get the non-localized page types to show up in the list regardless of the filtered locale.

For example, take an `employee` type which maps to an employee profile page on the front-end, which we want editors to be able to live preview and edit within Presentation. These documents only have a couple of translatable fields for which we use internationalized arrays instead of separate documents. With `requireLocale` set to `false` these documents are now accessible despite not having a `locale` field:

<img width="320" alt="Screenshot 2024-05-31 at 17 16 59" src="https://github.com/tinloof/sanity-kit/assets/1009069/7d613127-af51-4289-9842-db576d7d758f">