### PR TITLE
feat: allow using custom localizePathname function

### DIFF
--- a/.changeset/modern-frogs-give.md
+++ b/.changeset/modern-frogs-give.md
@@ -1,0 +1,6 @@
+---
+"@tinloof/sanity-studio": minor
+"@tinloof/sanity-web": minor
+---
+
+Add option to use a custom `localizePathname` function in the Pages plugin and in pathname fields. Thanks @marcusforsberg!

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -43,6 +43,7 @@ export function PathnameFieldComponent(props: PathnameInputProps): JSX.Element {
   const i18nOptions = fieldOptions?.i18n ?? {
     enabled: false,
     defaultLocaleId: undefined,
+    localizePathname: undefined,
   };
   const document = useFormValue([]) as DocumentWithLocale;
   const {
@@ -112,7 +113,8 @@ export function PathnameFieldComponent(props: PathnameInputProps): JSX.Element {
       locale: i18nOptions.enabled ? document.locale : undefined,
       pathname: value?.current,
     },
-    i18nOptions.defaultLocaleId || ""
+    i18nOptions.defaultLocaleId || "",
+    i18nOptions.localizePathname
   );
 
   const pathInput = useMemo(() => {

--- a/packages/sanity-studio/src/plugins/navigator/components/List.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/List.tsx
@@ -12,7 +12,6 @@ import {
 } from "@sanity/presentation";
 import { Badge, Box, Card, Flex, Stack, Text, Tooltip } from "@sanity/ui";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { localizePathname } from "@tinloof/sanity-web";
 import React, { useRef } from "react";
 import { useColorSchemeValue, useSchema } from "sanity";
 import { styled } from "styled-components";
@@ -193,7 +192,13 @@ const List = ({ loading }: { loading: boolean }) => {
 };
 
 const ListItem = ({ item, active, setActive, idx }: ListItemProps) => {
-  const { defaultLocaleId, setCurrentDir, currentDir } = useNavigator();
+  const {
+    defaultLocaleId,
+    setCurrentDir,
+    currentDir,
+    locale,
+    localizePathname,
+  } = useNavigator();
   const schema = useSchema();
   const innerRef = useRef<HTMLLIElement>(null);
   const listItemId = `item-${idx}`;
@@ -201,6 +206,7 @@ const ListItem = ({ item, active, setActive, idx }: ListItemProps) => {
     pathname: item.pathname || "",
     localeId: item.locale,
     isDefault: defaultLocaleId === item.locale,
+    fallbackLocaleId: locale,
   });
 
   const scheme = useColorSchemeValue();

--- a/packages/sanity-studio/src/plugins/navigator/context/index.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/context/index.tsx
@@ -9,6 +9,7 @@ import {
   TreeNode,
 } from "../../../types";
 import { buildTree, findTreeByPath } from "../utils";
+import { localizePathname } from "@tinloof/sanity-web";
 
 const CURRENT_DIR_PARAM = "sw-dir";
 const CURRENT_LOCALE_PARAM = "sw-locale";
@@ -26,6 +27,7 @@ const NavigatorContext = createContext<NavigatorContextType>({
   handleSearch: () => {},
   locale: undefined,
   defaultLocaleId: undefined,
+  localizePathname: localizePathname,
   setLocale: () => {},
   items: [],
 });
@@ -139,6 +141,7 @@ export const NavigatorProvider = ({
       value={{
         items,
         defaultLocaleId: i18n?.defaultLocaleId,
+        localizePathname: i18n?.localizePathname || localizePathname,
         rootTree,
         ...state,
         ...actions,

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -14,6 +14,7 @@ import {
 import { ObjectFieldProps, SlugValue } from "sanity";
 
 import { SlugContext } from "./hooks/usePathnameContext";
+import { LocalizePathnameFn } from "@tinloof/sanity-web";
 
 export type NormalizedCreatablePage = {
   title: string;
@@ -24,6 +25,7 @@ export type PagesNavigatorOptions = {
   i18n?: {
     locales: Locale[];
     defaultLocaleId?: string;
+    localizePathname?: LocalizePathnameFn;
   };
   creatablePages?: Array<NormalizedCreatablePage>;
 };
@@ -32,6 +34,7 @@ export type PagesNavigatorPluginOptions = PresentationPluginOptions & {
   i18n?: {
     locales: Locale[];
     defaultLocaleId?: string;
+    localizePathname?: LocalizePathnameFn;
   };
   navigator?: Pick<PresentationNavigatorOptions, "maxWidth" | "minWidth">;
   creatablePages?: Array<NormalizedCreatablePage | string>;
@@ -73,6 +76,7 @@ export type NavigatorContextType = {
   handleSearch: (value: string) => void;
   locale?: string;
   defaultLocaleId?: string;
+  localizePathname: LocalizePathnameFn;
   setLocale?: (value: string) => void;
   items: TreeNode[];
 };
@@ -172,6 +176,7 @@ export type PathnameOptions = SlugOptions & {
   i18n?: {
     enabled?: boolean;
     defaultLocaleId?: string;
+    localizePathname?: LocalizePathnameFn;
   };
 };
 

--- a/packages/sanity-web/src/types.ts
+++ b/packages/sanity-web/src/types.ts
@@ -26,3 +26,10 @@ export interface LocaleConfiguration {
 }
 
 export { SanityImageProps };
+
+export type LocalizePathnameFn = (opts: {
+  pathname: string;
+  localeId?: string;
+  isDefault?: boolean;
+  fallbackLocaleId?: string;
+}) => string;

--- a/packages/sanity-web/src/utils/urls/index.ts
+++ b/packages/sanity-web/src/utils/urls/index.ts
@@ -1,5 +1,5 @@
 import speakingurl from "speakingurl";
-import { DocForPath } from "../../types";
+import { DocForPath, LocalizePathnameFn } from "../../types";
 import { Slug } from "sanity";
 
 /**
@@ -49,14 +49,15 @@ export function formatPath(path: string): string {
 
 export function getDocumentPath(
   doc: DocForPath,
-  defaultLocaleId: string
+  defaultLocaleId: string,
+  localizePathnameFn?: LocalizePathnameFn
 ): string | undefined {
   if (typeof doc.pathname !== "string") return;
 
   const isDefault = doc.locale === defaultLocaleId;
 
   // Localize & format the final path
-  return localizePathname({
+  return (localizePathnameFn || localizePathname)({
     pathname: doc.pathname,
     localeId: doc.locale,
     isDefault,


### PR DESCRIPTION
Partially related to my proposed changes in #57 

We're using next-intl for our frontends using which we can have localized pathnames. Thus, a document that is stored in Sanity with a pathname of `/employees/marcus-forsberg` may be rewritten to `/sv/personal/marcus-forsberg`. Or, as in #57, we may have singleton document types that aren't translated at all through Sanity but that will have different pathnames per locale in the frontend.

This PR aims to solve this use case by allowing a custom `localizePathname` method to be passed both to the Navigator and to `definePathname`. In addition, the Navigator now sends through a `fallbackLocaleId` which is set to the currently filtered locale. This allows us to correctly rewrite the pathnames of documents that are not localized in Sanity to match how they'll appear in the frontend for the currently filtered locale.

This also allows other cutomizations to the pathname logic, such as not forcing pages in the default locale to not have a locale prefix (as is currently the case).
