### PR TITLE
feat(pathname): add autoNavigate option to hide the "Preview" button and automatically navigate as the pathname changes

### DIFF
--- a/.changeset/two-ears-listen.md
+++ b/.changeset/two-ears-listen.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": minor
+---
+
+Add `autoNavigate` option to hide the "Preview" button and automatically navigate as the pathname changes. Thanks @marcusforsberg!

--- a/packages/sanity-studio/README.md
+++ b/packages/sanity-studio/README.md
@@ -236,6 +236,29 @@ export default {
 };
 ```
 
+### Automatically navigate on pathname change
+
+By default, the `pathname` field comes with a "Preview" button which is used to navigate to the page within the Presentation iframe when the pathname changes. You can optionally disable this manual button and have the Presentation tool automatically navigate to the new pathname as it changes:
+
+```tsx
+import { definePathname } from "@tinloof/sanity-studio";
+
+export default defineType({
+  type: "document",
+  name: "modularPage",
+  fields: [
+    definePathname({
+      name: "pathname",
+      options: {
+        autoNavigate: true,
+      },
+    }),
+  ],
+});
+```
+
+The Presentation tool will now automatically navigate to the new pathname as the user types, with a 1 second debounce.
+
 ## Sections
 
 The `defineSection` field lets you easily define a new section schema. Used in combination with the `SectionsArrayInput` component, it will render a useful section picker in your Sanity documents.

--- a/packages/sanity-studio/package.json
+++ b/packages/sanity-studio/package.json
@@ -61,7 +61,8 @@
     "@tinloof/sanity-web": "workspace:*",
     "lodash": "^4.17.21",
     "nanoid": "^5.0.7",
-    "react-rx": "^2.1.3"
+    "react-rx": "^2.1.3",
+    "use-debounce": "^10.0.1"
   },
   "devDependencies": {
     "@sanity/pkg-utils": "^6.8.6",

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -64,12 +64,13 @@ export function PathnameFieldComponent(props: PathnameInputProps): JSX.Element {
   const folderCanUnlock = !readOnly && folderOptions.canUnlock;
 
   const navigate = useSafeNavigate();
-  const debouncedNavigate = useDebouncedCallback((preview?: string) => {
+  const preview = useSafePreview();
+
+  const debouncedNavigate = useDebouncedCallback((newPreview?: string) => {
     if (navigate) {
-      navigate(preview);
+      navigate(newPreview);
     }
   }, pathnameDebounceTime);
-  const preview = useSafePreview();
   const [debouncedValue] = useDebounce(value?.current, pathnameDebounceTime);
 
   const fullPathInputRef = useRef<HTMLInputElement>(null);

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -335,7 +335,9 @@ function runChange({
       i18nOptions?.localizePathname
     );
 
-    if (preview === prevLocalizedPathname) {
+    // Auto-navigate if this document is currently being previewed,
+    // or if it's a brand new document being created.
+    if (preview === prevLocalizedPathname || !document._createdAt) {
       navigate(newLocalizedPathname);
     }
   }

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -180,6 +180,7 @@ export type PathnameOptions = SlugOptions & {
     defaultLocaleId?: string;
     localizePathname?: LocalizePathnameFn;
   };
+  autoNavigate?: boolean;
 };
 
 export type PathnameParams = Omit<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -460,6 +460,9 @@ importers:
       react-rx:
         specifier: ^2.1.3
         version: 2.1.3(react@18.2.0)(rxjs@7.8.1)
+      use-debounce:
+        specifier: ^10.0.1
+        version: 10.0.1(react@18.2.0)
     devDependencies:
       '@sanity/pkg-utils':
         specifier: ^6.8.6
@@ -11935,6 +11938,15 @@ packages:
       '@types/react': 18.2.79
       react: 18.2.0
       tslib: 2.6.2
+
+  /use-debounce@10.0.1(react@18.2.0):
+    resolution: {integrity: sha512-0uUXjOfm44e6z4LZ/woZvkM8FwV1wiuoB6xnrrOmeAEjRDDzTLQNRFtYHvqUsJdrz1X37j0rVGIVp144GLHGKg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /use-device-pixel-ratio@1.1.2(react@18.2.0):
     resolution: {integrity: sha512-nFxV0HwLdRUt20kvIgqHYZe6PK/v4mU1X8/eLsT1ti5ck0l2ob0HDRziaJPx+YWzBo6dMm4cTac3mcyk68Gh+A==}


### PR DESCRIPTION
This PR adds an optional `autoNavigate` option to the pathname field. Setting it to true will result in the "Preview" button being hidden and the Presentation tool automatically navigating to the new pathname as it changes (with a 1 second debounce to avoid spamming the frontend/API). You can see the pathname changing in the Presentation iframe in the video below:


https://github.com/tinloof/sanity-kit/assets/1009069/ee21347b-5356-403e-a7f8-d7eb7ed7fea5

