### PR TITLE
feat(pathname): implement "source" option and "Generate" button

### DIFF
--- a/.changeset/metal-experts-stare.md
+++ b/.changeset/metal-experts-stare.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": minor
+---
+
+Add support for the `source` field, which when set will render a button to generate the pathname similar to Sanity's `Slug` type. Thanks @marcusforsberg!

--- a/packages/sanity-studio/README.md
+++ b/packages/sanity-studio/README.md
@@ -69,6 +69,27 @@ export default defineType({
 
 Documents with a defined `pathname` field value are now recognized as pages and are automatically grouped into directories in the pages navigator.
 
+Like Sanity's native `slug` type, the `pathname` supports a `source` option which can be used to generate the pathname from another field on the document, eg. the title:
+
+```tsx
+import { definePathname } from "@tinloof/sanity-studio";
+
+export default defineType({
+  type: "document",
+  name: "modularPage",
+  fields: [
+    definePathname({
+      name: "pathname",
+      options: {
+        source: "title",
+      },
+    }),
+  ],
+});
+```
+
+The `source` can also be a function (which can be asynchronous), returning the generated pathname.
+
 ### Enabling page creation
 
 Use the `creatablePages` option to define which schema types can be used to create pages.

--- a/packages/sanity-studio/package.json
+++ b/packages/sanity-studio/package.json
@@ -57,6 +57,7 @@
     "@sanity/incompatible-plugin": "^1.0.4",
     "@sanity/presentation": "^1.12.8",
     "@sanity/ui": "^2.1.4",
+    "@sanity/util": "^3.45.0",
     "@tanstack/react-virtual": "^3.4.0",
     "@tinloof/sanity-web": "workspace:*",
     "lodash": "^4.17.21",

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -72,11 +72,17 @@ export function PathnameFieldComponent(props: PathnameInputProps): JSX.Element {
   const fieldOptions = props.schemaType.options as PathnameOptions | undefined;
   const { prefix } = usePathnamePrefix(props);
   const folderOptions = fieldOptions?.folder ?? { canUnlock: true };
-  const i18nOptions = fieldOptions?.i18n ?? {
-    enabled: false,
-    defaultLocaleId: undefined,
-    localizePathname: undefined,
-  };
+
+  const i18nOptions = useMemo(
+    () =>
+      fieldOptions?.i18n ?? {
+        enabled: false,
+        defaultLocaleId: undefined,
+        localizePathname: undefined,
+      },
+    [fieldOptions]
+  );
+
   const autoNavigate = fieldOptions?.autoNavigate ?? false;
   const document = useFormValue([]) as DocumentWithLocale;
   const {

--- a/packages/sanity-studio/src/hooks/useAsync.ts
+++ b/packages/sanity-studio/src/hooks/useAsync.ts
@@ -1,0 +1,62 @@
+// Copied from https://github.com/sanity-io/sanity/blob/next/packages/sanity/src/core/form/inputs/Slug/utils/useAsync.tsx
+
+import { type DependencyList, useCallback, useRef, useState } from "react";
+
+export type AsyncCompleteState<T> = {
+  status: "complete";
+  result: T;
+};
+export type AsyncPendingState = {
+  status: "pending";
+};
+export type AsyncErrorState = {
+  status: "error";
+  error: Error;
+};
+
+export type AsyncState<T> =
+  | AsyncPendingState
+  | AsyncCompleteState<T>
+  | AsyncErrorState;
+
+/**
+ * Takes an async function and returns a [AsyncState<value>, callback] pair.
+ * Whenever the callback is invoked, a new AsyncState is returned.
+ * If the returned callback is called again before the previous callback has settled, the resolution of the previous one will be ignored, thus preventing race conditions.
+ * @param fn - an async function that returns a value
+ * @param dependencies - list of dependencies that will return a new [value, callback] pair
+ */
+export function useAsync<T, U>(
+  fn: (arg: U) => Promise<T>,
+  dependencies: DependencyList
+): [null | AsyncState<T>, (arg: U) => void] {
+  const [state, setState] = useState<AsyncState<T> | null>(null);
+
+  const lastId = useRef(0);
+
+  const wrappedCallback = useCallback(
+    (arg: U) => {
+      const asyncId = ++lastId.current;
+      setState({ status: "pending" });
+
+      Promise.resolve()
+        .then(() => fn(arg))
+        .then(
+          (res) => {
+            if (asyncId === lastId.current) {
+              setState({ status: "complete", result: res });
+            }
+          },
+          (err) => {
+            if (asyncId === lastId.current) {
+              setState({ status: "error", error: err });
+            }
+          }
+        );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- this is under control, and enforced by our linter setup
+    [fn, ...dependencies]
+  );
+
+  return [state, wrappedCallback];
+}

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -7,9 +7,11 @@ import {
   ObjectDefinition,
   ObjectOptions,
   ObjectSchemaType,
+  Path,
   SanityDocument,
   SlugDefinition,
   SlugOptions,
+  SlugSourceFn,
 } from "sanity";
 import { ObjectFieldProps, SlugValue } from "sanity";
 
@@ -170,7 +172,13 @@ export type PathnamePrefix =
   | string
   | ((doc: SanityDocument, context: SlugContext) => Promise<string> | string);
 
-export type PathnameOptions = SlugOptions & {
+export type PathnameSourceFn = (
+  document: SanityDocument,
+  context: SlugContext
+) => string | Promise<string>;
+
+export type PathnameOptions = Pick<SlugOptions, "isUnique"> & {
+  source?: string | Path | PathnameSourceFn;
   prefix?: PathnamePrefix;
   folder?: {
     canUnlock?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -429,7 +429,7 @@ importers:
         version: 1.3.0
       '@sanity/document-internationalization':
         specifier: ^3.0.0
-        version: 3.0.0(@sanity/mutator@3.39.0)(@sanity/ui@2.1.4)(@sanity/util@3.39.0)(react-dom@18.2.0)(react-fast-compare@3.2.2)(react@18.2.0)(rxjs@7.8.1)(sanity@3.39.0)(styled-components@6.1.8)
+        version: 3.0.0(@sanity/mutator@3.39.0)(@sanity/ui@2.1.4)(@sanity/util@3.45.0)(react-dom@18.2.0)(react-fast-compare@3.2.2)(react@18.2.0)(rxjs@7.8.1)(sanity@3.39.0)(styled-components@6.1.8)
       '@sanity/icons':
         specifier: ^2.11.8
         version: 2.11.8(react@18.2.0)
@@ -445,6 +445,9 @@ importers:
       '@sanity/ui':
         specifier: ^2.1.4
         version: 2.1.4(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8)
+      '@sanity/util':
+        specifier: ^3.45.0
+        version: 3.45.0
       '@tanstack/react-virtual':
         specifier: ^3.4.0
         version: 3.4.0(react-dom@18.2.0)(react@18.2.0)
@@ -3669,6 +3672,17 @@ packages:
     transitivePeerDependencies:
       - debug
 
+  /@sanity/client@6.20.0:
+    resolution: {integrity: sha512-p6ENOFBR1QQirKj6zVYPDeZNVHMVV+3UVo+RptZDQPuyYyfAOA/TwJzX3cE19O2G4CgWnLfkmOOg6RcFjzFMWQ==}
+    engines: {node: '>=14.18'}
+    dependencies:
+      '@sanity/eventsource': 5.0.2
+      get-it: 8.6.0
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@sanity/codegen@3.39.0:
     resolution: {integrity: sha512-ab42ElTO5Bu8TeU/IPYlwe9bRXsV05LMDPPqBDN+70egGJ1LB3s/FNwhC2e0LM+t89Qha8VFAFOUadmaru+ddA==}
     engines: {node: '>=18'}
@@ -3714,7 +3728,7 @@ packages:
     dependencies:
       '@sanity/diff-match-patch': 3.1.1
 
-  /@sanity/document-internationalization@3.0.0(@sanity/mutator@3.39.0)(@sanity/ui@2.1.4)(@sanity/util@3.39.0)(react-dom@18.2.0)(react-fast-compare@3.2.2)(react@18.2.0)(rxjs@7.8.1)(sanity@3.39.0)(styled-components@6.1.8):
+  /@sanity/document-internationalization@3.0.0(@sanity/mutator@3.39.0)(@sanity/ui@2.1.4)(@sanity/util@3.45.0)(react-dom@18.2.0)(react-fast-compare@3.2.2)(react@18.2.0)(rxjs@7.8.1)(sanity@3.39.0)(styled-components@6.1.8):
     resolution: {integrity: sha512-HQQiix1MCNtXOLpi1ILjpT8EGk55Yv7515DVWcJAHLSjfpYAo9wvGfkZhRhP5lzWxLj2DsyeBX2zkF2J3QDs2A==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -3733,7 +3747,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       sanity: 3.39.0(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)(styled-components@6.1.8)
-      sanity-plugin-internationalized-array: 2.0.0(@sanity/ui@2.1.4)(@sanity/util@3.39.0)(react-dom@18.2.0)(react@18.2.0)(sanity@3.39.0)(styled-components@6.1.8)
+      sanity-plugin-internationalized-array: 2.0.0(@sanity/ui@2.1.4)(@sanity/util@3.45.0)(react-dom@18.2.0)(react@18.2.0)(sanity@3.39.0)(styled-components@6.1.8)
       sanity-plugin-utils: 1.6.4(@sanity/ui@2.1.4)(react-dom@18.2.0)(react-fast-compare@3.2.2)(react@18.2.0)(rxjs@7.8.1)(sanity@3.39.0)(styled-components@6.1.8)
       styled-components: 6.1.8(react-dom@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
@@ -3876,7 +3890,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@sanity/language-filter@4.0.2(@sanity/ui@2.1.4)(@sanity/util@3.39.0)(react-dom@18.2.0)(react@18.2.0)(sanity@3.39.0)(styled-components@6.1.8):
+  /@sanity/language-filter@4.0.2(@sanity/ui@2.1.4)(@sanity/util@3.45.0)(react-dom@18.2.0)(react@18.2.0)(sanity@3.39.0)(styled-components@6.1.8):
     resolution: {integrity: sha512-guL7vZv/QwDdbzVbCA8YqY8G0tH6KW2obyp5UCbFvFy9NqlmfuaHtle/VIO+UwqbCXck2Xpz0WihFeQHHjhCcw==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -3890,7 +3904,7 @@ packages:
       '@sanity/icons': 2.11.8(react@18.2.0)
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.2.0)(react@18.2.0)
       '@sanity/ui': 2.1.4(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8)
-      '@sanity/util': 3.39.0
+      '@sanity/util': 3.45.0
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -4237,6 +4251,15 @@ packages:
     transitivePeerDependencies:
       - debug
 
+  /@sanity/types@3.45.0:
+    resolution: {integrity: sha512-CjqeGDbp7iEQtw5ceFMZGCIKckZd77c4x34eZ530oKRiXaxS0hcpWgHd3hDK+xWuNFiaJcPG2OqbFUfRpGrRoQ==}
+    dependencies:
+      '@sanity/client': 6.20.0
+      '@types/react': 18.2.79
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@sanity/ui@2.1.4(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8):
     resolution: {integrity: sha512-upOLalVCaDrW774mOwNo/f5rNsHcJASGElf/e1vLCViltdSmJ3rb7rdTRKIT26+LE4Jl0ACJIkli6J/qbGWpjQ==}
     engines: {node: '>=14.0.0'}
@@ -4269,19 +4292,6 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /@sanity/util@3.39.0:
-    resolution: {integrity: sha512-MJ16qJHG70CehPNz31H5wISvu7IYNMoI3wjQ3qOzQPALHyc0PbhxW03MNlmBw+Px3tWS+eYyPedpGTJT56o1SQ==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@sanity/client': 6.15.20
-      '@sanity/types': 3.39.0
-      get-random-values-esm: 1.0.2
-      moment: 2.30.1
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /@sanity/util@3.39.0(debug@3.2.7):
     resolution: {integrity: sha512-MJ16qJHG70CehPNz31H5wISvu7IYNMoI3wjQ3qOzQPALHyc0PbhxW03MNlmBw+Px3tWS+eYyPedpGTJT56o1SQ==}
     engines: {node: '>=18'}
@@ -4305,6 +4315,19 @@ packages:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - debug
+
+  /@sanity/util@3.45.0:
+    resolution: {integrity: sha512-m5zvBglUEnCqYBjeLP0Gatt8L5pSj80p2pubPpxccEq1llMRiGNb5iB3jK4QJHaYnmcMKncLV6rOWJr9TNz7+A==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@sanity/client': 6.20.0
+      '@sanity/types': 3.45.0
+      get-random-values-esm: 1.0.2
+      moment: 2.30.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /@sanity/uuid@3.0.2:
     resolution: {integrity: sha512-vzdhqOrX7JGbMyK40KuIwwyXHm7GMLOGuYgn3xlC09e4ZVNofUO5mgezQqnRv0JAMthIRhofqs9f6ufUjMKOvw==}
@@ -7632,6 +7655,19 @@ packages:
     transitivePeerDependencies:
       - debug
 
+  /get-it@8.6.0:
+    resolution: {integrity: sha512-ZFNZc3eKkYRHI5a7p3SAc3s0eBJgLL+qqpF7wpoFbTdzbHKC/XHu+6ot9RZTe6aoYGmZqf3Mdl62XdgiWJ7/ZQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      decompress-response: 7.0.0
+      follow-redirects: 1.15.6(debug@3.2.7)
+      is-retry-allowed: 2.2.0
+      progress-stream: 2.0.0
+      tunnel-agent: 0.6.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /get-latest-version@5.1.0:
     resolution: {integrity: sha512-Q6IBWr/zzw57zIkJmNhI23eRTw3nZ4BWWK034meLwOYU9L3J3IpXiyM73u2pYUwN6U7ahkerCwg2T0jlxiLwsw==}
     engines: {node: '>=14.18'}
@@ -10632,7 +10668,7 @@ packages:
     dependencies:
       '@sanity/diff-match-patch': 3.1.1
 
-  /sanity-plugin-internationalized-array@2.0.0(@sanity/ui@2.1.4)(@sanity/util@3.39.0)(react-dom@18.2.0)(react@18.2.0)(sanity@3.39.0)(styled-components@6.1.8):
+  /sanity-plugin-internationalized-array@2.0.0(@sanity/ui@2.1.4)(@sanity/util@3.45.0)(react-dom@18.2.0)(react@18.2.0)(sanity@3.39.0)(styled-components@6.1.8):
     resolution: {integrity: sha512-NRxAziPAy++veE1nR3JxzrfRXPfhoBK40A3ggSAS0ZMUFJ9aFZajVgmkhkR3kZtff0oFbX0zcHigrhRj0X3TyQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -10644,7 +10680,7 @@ packages:
     dependencies:
       '@sanity/icons': 2.11.8(react@18.2.0)
       '@sanity/incompatible-plugin': 1.0.4(react-dom@18.2.0)(react@18.2.0)
-      '@sanity/language-filter': 4.0.2(@sanity/ui@2.1.4)(@sanity/util@3.39.0)(react-dom@18.2.0)(react@18.2.0)(sanity@3.39.0)(styled-components@6.1.8)
+      '@sanity/language-filter': 4.0.2(@sanity/ui@2.1.4)(@sanity/util@3.45.0)(react-dom@18.2.0)(react@18.2.0)(sanity@3.39.0)(styled-components@6.1.8)
       '@sanity/ui': 2.1.4(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@6.1.8)
       fast-deep-equal: 3.1.3
       lodash: 4.17.21


### PR DESCRIPTION
Fixes #19 

This PR adds support for the `source` field, like on the native Slug type. When set, there will be a button to generate the pathname:

![Screenshot 2024-06-10 at 13 55 41](https://github.com/tinloof/sanity-kit/assets/1009069/3981ecaa-464d-43d3-b616-8473326d689f)

Any existing folder will remain untouched, as only the final segment is updated.

As part of this I updated the `PathnameParams` type so that it no longer inherits the `maxLength` and `slugify` properties from `SlugOptions` since these aren't supported.