### PR TITLE
feat: add ability to set custom icons and titles for folders in the navigator

### DIFF
--- a/.changeset/wise-kids-dream.md
+++ b/.changeset/wise-kids-dream.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": minor
+---
+
+Add `folders` config option which can be used to customize the icons and titles for individual folders based on their pathnames. Thanks @marcusforsberg!

--- a/packages/sanity-studio/README.md
+++ b/packages/sanity-studio/README.md
@@ -236,6 +236,31 @@ export default {
 };
 ```
 
+### Customizing folders
+
+By default, folders will have a folder icon and use the pathname/prefix capitalized as the title. You can customize this for individual folders using the `folders` config option on the plugin:
+
+```tsx
+export default defineConfig({
+  // ... other Sanity Studio config
+  plugins: [
+    pages({
+      previewUrl: {
+        previewMode: {
+          enable: "/api/draft",
+        },
+      },
+      folders: {
+        "/news": {
+          title: "Articles",
+          icon: NewspaperIcon,
+        },
+      },
+    }),
+  ],
+});
+```
+
 ### Automatically navigate on pathname change
 
 By default, the `pathname` field comes with a "Preview" button which is used to navigate to the page within the Presentation iframe when the pathname changes. You can optionally disable this manual button and have the Presentation tool automatically navigate to the new pathname as it changes:

--- a/packages/sanity-studio/src/plugins/navigator/components/DefaultPagesNavigator.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/DefaultPagesNavigator.tsx
@@ -36,7 +36,11 @@ function DefaultPagesNavigator(props: PagesNavigatorOptions) {
 
   return (
     <ThemeProvider>
-      <NavigatorProvider i18n={props.i18n} data={data || []}>
+      <NavigatorProvider
+        i18n={props.i18n}
+        folders={props.folders}
+        data={data || []}
+      >
         <Header pages={props.creatablePages}>
           <SearchBox />
           {props.i18n?.locales?.length && props.i18n.locales.length > 1 ? (

--- a/packages/sanity-studio/src/plugins/navigator/components/List.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/List.tsx
@@ -12,7 +12,7 @@ import {
 } from "@sanity/presentation";
 import { Badge, Box, Card, Flex, Stack, Text, Tooltip } from "@sanity/ui";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import React, { useRef } from "react";
+import React, { createElement, useRef } from "react";
 import { useColorSchemeValue, useSchema } from "sanity";
 import { styled } from "styled-components";
 
@@ -198,6 +198,7 @@ const ListItem = ({ item, active, setActive, idx }: ListItemProps) => {
     currentDir,
     locale,
     localizePathname,
+    folders,
   } = useNavigator();
   const schema = useSchema();
   const innerRef = useRef<HTMLLIElement>(null);
@@ -310,7 +311,7 @@ const ListItem = ({ item, active, setActive, idx }: ListItemProps) => {
             {item._type !== "folder" ? (
               <PreviewElement fallback={item.title} type="title" item={item} />
             ) : (
-              item.title
+              folders?.[path]?.title || item.title
             )}
           </TextElement>
           <TextElement
@@ -411,13 +412,18 @@ const ListItem = ({ item, active, setActive, idx }: ListItemProps) => {
 };
 
 const ItemIcon = ({ item }: { item: TreeNode }) => {
-  const iconProps = {
-    fontSize: "calc(21 / 16 * 1em)",
-    color: "var(--card-icon-color)",
-  };
+  const { folders } = useNavigator();
 
   if (item._type === "folder") {
-    return <FolderIcon {...iconProps} />;
+    return createElement(
+      item.pathname && folders?.[item.pathname]?.icon
+        ? folders[item.pathname].icon!
+        : FolderIcon,
+      {
+        fontSize: "calc(21 / 16 * 1em)",
+        color: "var(--card-icon-color)",
+      }
+    );
   }
 
   return (

--- a/packages/sanity-studio/src/plugins/navigator/context/index.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/context/index.tsx
@@ -29,6 +29,7 @@ const NavigatorContext = createContext<NavigatorContextType>({
   defaultLocaleId: undefined,
   localizePathname: localizePathname,
   setLocale: () => {},
+  folders: {},
   items: [],
 });
 
@@ -64,9 +65,11 @@ function reducer(state: State, action: ReducerAction) {
 export const NavigatorProvider = ({
   data,
   i18n,
+  folders,
   children,
 }: {
   i18n?: PagesNavigatorOptions["i18n"];
+  folders?: PagesNavigatorOptions["folders"];
   data: Page[];
   children: React.ReactNode;
 }) => {
@@ -146,6 +149,7 @@ export const NavigatorProvider = ({
         items,
         defaultLocaleId: i18n?.defaultLocaleId,
         localizePathname: i18n?.localizePathname || localizePathname,
+        folders,
         rootTree,
         ...state,
         ...actions,

--- a/packages/sanity-studio/src/plugins/navigator/index.ts
+++ b/packages/sanity-studio/src/plugins/navigator/index.ts
@@ -46,6 +46,7 @@ export const pages = definePlugin<PagesNavigatorPluginOptions>((config) => {
             component: createPagesNavigator({
               i18n: config.i18n,
               creatablePages: normalizedCreatablePages,
+              folders: config.folders,
             }),
             minWidth: config.navigator?.minWidth ?? 320,
             maxWidth: config.navigator?.maxWidth ?? 480,

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -3,6 +3,7 @@ import {
   NavigatorOptions as PresentationNavigatorOptions,
   PresentationPluginOptions,
 } from "@sanity/presentation";
+import { LocalizePathnameFn } from "@tinloof/sanity-web";
 import {
   ObjectDefinition,
   ObjectOptions,
@@ -12,14 +13,20 @@ import {
   SlugOptions,
 } from "sanity";
 import { ObjectFieldProps, SlugValue } from "sanity";
+import { FieldDefinitionBase } from "sanity";
 
 import { SlugContext } from "./hooks/usePathnameContext";
-import { LocalizePathnameFn } from "@tinloof/sanity-web";
-import { FieldDefinitionBase } from "sanity";
 
 export type NormalizedCreatablePage = {
   title: string;
   type: string;
+};
+
+export type FoldersConfig = {
+  [pathname: string]: {
+    title?: string;
+    icon?: React.ElementType;
+  };
 };
 
 export type PagesNavigatorOptions = {
@@ -30,6 +37,7 @@ export type PagesNavigatorOptions = {
     localizePathname?: LocalizePathnameFn;
   };
   creatablePages?: Array<NormalizedCreatablePage>;
+  folders?: FoldersConfig;
 };
 
 export type PagesNavigatorPluginOptions = PresentationPluginOptions & {
@@ -41,6 +49,7 @@ export type PagesNavigatorPluginOptions = PresentationPluginOptions & {
   };
   navigator?: Pick<PresentationNavigatorOptions, "maxWidth" | "minWidth">;
   creatablePages?: Array<NormalizedCreatablePage | string>;
+  folders?: FoldersConfig;
   title?: string;
 };
 
@@ -81,6 +90,7 @@ export type NavigatorContextType = {
   defaultLocaleId?: string;
   localizePathname: LocalizePathnameFn;
   setLocale?: (value: string) => void;
+  folders?: FoldersConfig;
   items: TreeNode[];
 };
 


### PR DESCRIPTION
This PR adds a `folders` option to the plugin which can be used to change how individual folders render in the navigator, specifically their title and/or icon.

This can be used to make it a little easier to find specific folders, for example the /products folder could have the same icon as the Products schema type, and the /news folder could have a newspaper icon.

Changing the title can be useful if the slug doesn't match the name of the schema type: eg. the `article` schema type may live under the `/news` prefix, but the editors are used to referring to "Articles" so it's easier for them to look for the "Articles" folder than the automatically titled "News" folder. It's also useful for localized sites using a [custom `localizePathname`](https://github.com/tinloof/sanity-kit/pull/58) where folders can have different prefixes in different languages; eg. the "/employee" folder's path may be "/personal" in Swedish but since the Studio is in English the folder title should display as "Employees" regardless of locale.

```ts
    folders: {
      '/news': {
        title: 'Articles',
        icon: NewspaperIcon
      }
    }
```

<img width="479" alt="Screenshot 2024-06-11 at 15 36 20" src="https://github.com/tinloof/sanity-kit/assets/1009069/08e24dbd-08cf-4006-beb9-4b1819cdf228">
