### PR TITLE
fix(pathname): hide Preview button when outside of Presentation tool (eg. in Structure tool)

### DIFF
--- a/.changeset/fluffy-phones-explain.md
+++ b/.changeset/fluffy-phones-explain.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": patch
+---
+
+Hide the "Preview" button from the `pathname` field when used in the Structure Tool (where it has no effect).

--- a/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
+++ b/packages/sanity-studio/src/components/PathnameFieldComponent.tsx
@@ -423,21 +423,21 @@ function PreviewButton({ localizedPathname }: { localizedPathname: string }) {
   }, [navigate, localizedPathname]);
 
   return (
-    <Button
-      text="Preview"
-      fontSize={1}
-      height={"100%"}
-      mode="default"
-      tone="default"
-      icon={EyeOpenIcon}
-      disabled={
-        !navigate ||
-        typeof localizedPathname !== "string" ||
-        preview === localizedPathname
-      }
-      title="Preview page"
-      onClick={handleClick}
-    />
+    !!navigate && (
+      <Button
+        text="Preview"
+        fontSize={1}
+        height={"100%"}
+        mode="default"
+        tone="default"
+        icon={EyeOpenIcon}
+        disabled={
+          typeof localizedPathname !== "string" || preview === localizedPathname
+        }
+        title="Preview page"
+        onClick={handleClick}
+      />
+    )
   );
 }
 


### PR DESCRIPTION
As [suggested by @Jamiewarb](https://github.com/tinloof/sanity-kit/issues/19#issuecomment-2066934062), this PR hides the Preview button entirely when outside of the Presentation tool. Previously it would still be there but always disabled since it has no function outside of the Presentation tool. When working in the Structure tool I think it makes the most sense to not have that dead button there at all.