### PR TITLE
feat: properly render custom folder titles with i18n enabled + add ability to localize folder titles

### DIFF
--- a/.changeset/fast-dragons-count.md
+++ b/.changeset/fast-dragons-count.md
@@ -2,4 +2,4 @@
 "@tinloof/sanity-studio": patch
 ---
 
-Properly render custom folder titles when i18n is enabled
+Properly render custom folder titles when i18n is enabled and add ability to have localized folder titles using a callback function.

--- a/.changeset/fast-dragons-count.md
+++ b/.changeset/fast-dragons-count.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": patch
+---
+
+Properly render custom folder titles when i18n is enabled

--- a/packages/sanity-studio/src/plugins/navigator/components/List.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/List.tsx
@@ -311,7 +311,7 @@ const ListItem = ({ item, active, setActive, idx }: ListItemProps) => {
             {item._type !== "folder" ? (
               <PreviewElement fallback={item.title} type="title" item={item} />
             ) : (
-              folders?.[path]?.title || item.title
+              folders?.[item.pathname || ""]?.title || item.title
             )}
           </TextElement>
           <TextElement

--- a/packages/sanity-studio/src/plugins/navigator/components/List.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/List.tsx
@@ -16,7 +16,12 @@ import React, { createElement, useRef } from "react";
 import { useColorSchemeValue, useSchema } from "sanity";
 import { styled } from "styled-components";
 
-import { ListItemProps, PageTreeNode, TreeNode } from "../../../types";
+import {
+  FoldersConfig,
+  ListItemProps,
+  PageTreeNode,
+  TreeNode,
+} from "../../../types";
 import { useNavigator } from "../context";
 import { PreviewElement } from "./Preview";
 
@@ -311,7 +316,7 @@ const ListItem = ({ item, active, setActive, idx }: ListItemProps) => {
             {item._type !== "folder" ? (
               <PreviewElement fallback={item.title} type="title" item={item} />
             ) : (
-              folders?.[item.pathname || ""]?.title || item.title
+              <FolderTitle item={item} locale={locale} folders={folders} />
             )}
           </TextElement>
           <TextElement
@@ -409,6 +414,30 @@ const ListItem = ({ item, active, setActive, idx }: ListItemProps) => {
       ) : null}
     </ListItemWrapper>
   );
+};
+
+const FolderTitle = ({
+  item,
+  locale,
+  folders,
+}: {
+  item: TreeNode;
+  locale: string | undefined;
+  folders: FoldersConfig | undefined;
+}) => {
+  const customTitle = folders?.[item.pathname || ""]?.title;
+
+  if (customTitle) {
+    return (
+      <>
+        {typeof customTitle === "string"
+          ? customTitle
+          : customTitle(item, locale)}
+      </>
+    );
+  }
+
+  return <>{item.title}</>;
 };
 
 const ItemIcon = ({ item }: { item: TreeNode }) => {

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -24,9 +24,11 @@ export type NormalizedCreatablePage = {
   type: string;
 };
 
+export type FolderTitleFn = (item: TreeNode, locale?: string) => string;
+
 export type FoldersConfig = {
   [pathname: string]: {
-    title?: string;
+    title?: string | FolderTitleFn;
     icon?: React.ElementType;
   };
 };


### PR DESCRIPTION
#66 contained a mistake causing custom folder titles to not be applied in the navigator when i18n is enabled. This fixes that by looking at the original pathname instead of the localized one (same as it already did for the icons).

Also includes the ability to use a callback function to generate the folder title based on the selected locale.