### PR TITLE
fix: render correct preview titles

### DIFF
--- a/.changeset/twenty-books-promise.md
+++ b/.changeset/twenty-books-promise.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": patch
+---
+
+Correctly render document titles.

--- a/packages/sanity-studio/src/plugins/navigator/components/Preview.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/Preview.tsx
@@ -1,7 +1,7 @@
 import { isImageSource, SanityImageSource } from "@sanity/asset-utils";
 import { DocumentIcon } from "@sanity/icons";
 import imageUrlBuilder from "@sanity/image-url";
-import React from "react";
+import React, { useMemo } from "react";
 import { isValidElementType } from "react-is";
 import { useMemoObservable } from "react-rx";
 import {
@@ -10,6 +10,7 @@ import {
   ImageUrlFitMode,
   isString,
   SanityDefaultPreviewProps,
+  SanityDocument,
   SchemaType,
   useClient,
   useDocumentPreviewStore,
@@ -58,10 +59,17 @@ const Preview = ({
   const published = previewState?.published;
   const isLoading = previewState?.isLoading;
 
+  const sanityDocument = useMemo(() => {
+    return {
+      _id: item._id,
+      _type: schemaType.name,
+    } as SanityDocument;
+  }, [item._id, schemaType.name]);
+
   const previewValues = getPreviewValueWithFallback({
     draft,
     published,
-    value: { ...item },
+    value: sanityDocument,
   });
 
   const showPreview =


### PR DESCRIPTION
There's an issue with the document preview titles in the navigator.
The titles end up always being generated from the pathname, regardless of a document's actual title.

This is problematic, for example, if a page's title and pathname differ:

<img width="1727" alt="Screenshot 2024-08-27 at 12 08 55" src="https://github.com/user-attachments/assets/53a1afdd-7a28-41d3-88af-ba0639b8ad71">

It's also an issue for non-English titles, for example:

<img width="1728" alt="Screenshot 2024-08-27 at 12 09 45" src="https://github.com/user-attachments/assets/d4f83ac9-a3c9-4d4a-ac18-629c97964690">

This PR fixes the preview logic so that the correct titles are always shown:

<img width="1728" alt="Screenshot 2024-08-27 at 12 11 31" src="https://github.com/user-attachments/assets/2c3d9ce9-d125-405c-830f-6fcfa1454565">

This should make it clear to editors which page is which, even if the pathname differs or if there are special characters or capitalized characters in the title.

I used these components in Sanity's repo as reference for this change:
- https://github.com/sanity-io/sanity/blob/14530aa3b0072c70b8c9cf4a5182af78ec975f81/packages/sanity/src/core/studio/components/navbar/search/components/searchResults/item/SearchResultItemPreview.tsx#L61
- https://github.com/sanity-io/sanity/blob/14530aa3b0072c70b8c9cf4a5182af78ec975f81/packages/sanity/src/core/studio/components/navbar/search/components/filters/common/ReferencePreviewTitle.tsx#L28

It seems to work well, but I'm not too well-versed in the inner workings of these parts so there may well be a better way to do it, so I'm open to adjusting this as needed.
