### PR TITLE
fix pages navigator scrolling to last item issue

### DIFF
--- a/packages/sanity-studio/src/plugins/navigator/components/List.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/List.tsx
@@ -34,7 +34,7 @@ const ListWrapper = styled(Box)`
   border: 2px solid transparent;
   padding: 2px;
   border-radius: 8px;
-  height: 88vh;
+  height: calc(100vh - 160px);
   overflow-y: auto;
   margin: 0;
   display: flex;


### PR DESCRIPTION
This PR resolves an issue where the last item in the list was not visible when scrolling to the end.