### PR TITLE
deps: Move sanity to peer deps

### DIFF
--- a/packages/sanity-web/package.json
+++ b/packages/sanity-web/package.json
@@ -31,13 +31,13 @@
   },
   "peerDependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "sanity": "^3.62.0"
   },
   "dependencies": {
     "@portabletext/react": "^3.1.0",
     "@sanity/asset-utils": "^1.3.0",
     "@sanity/image-url": "^1.0.2",
-    "sanity": "^3.62.0",
     "speakingurl": "^14.0.1"
   }
 }


### PR DESCRIPTION
As `sanity` is a dependency, we get warnings whenever it's slightly behind on version.

As a peer dependency, we're able to specify a range in which the package will work, but prevent version mismatches with end users if the `sanity-web` is not kept up to date with all Sanity releases.

This equals less maintenance burden for this package and its maintainers

```shell
$ pnpm i

 WARN  Issues with peer dependencies found
apps/sanity
└─┬ @tinloof/sanity-studio 1.4.0
  └─┬ @tinloof/sanity-web 0.6.0
    └─┬ sanity 3.62.0
      └─┬ @portabletext/editor 1.5.5
        ├── ✕ unmet peer @sanity/block-tools@^3.63.0: found 3.62.0 in sanity
        ├── ✕ unmet peer @sanity/schema@^3.63.0: found 3.62.0 in sanity
        ├── ✕ unmet peer @sanity/types@^3.63.0: found 3.62.0 in sanity
        └── ✕ unmet peer @sanity/util@^3.63.0: found 3.62.0 in sanity

packages/sanity-toolkit
└─┬ @tinloof/sanity-studio 1.4.0
  └─┬ @tinloof/sanity-web 0.6.0
    └─┬ sanity 3.62.0
      └─┬ @portabletext/editor 1.5.5
        ├── ✕ unmet peer @sanity/block-tools@^3.63.0: found 3.62.0 in sanity
        ├── ✕ unmet peer @sanity/schema@^3.63.0: found 3.62.0 in sanity
        ├── ✕ unmet peer @sanity/types@^3.63.0: found 3.62.0 in sanity
        └── ✕ unmet peer @sanity/util@^3.63.0: found 3.62.0 in sanity
```