### PR TITLE
Disable creation plugin, document-internationalization downgrade

### DIFF
--- a/.changeset/red-trains-behave.md
+++ b/.changeset/red-trains-behave.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": minor
+---
+
+Disable creation plugin

--- a/packages/sanity-studio/README.md
+++ b/packages/sanity-studio/README.md
@@ -26,6 +26,7 @@ npm install @tinloof/sanity-studio
 - [`documentI18n`](#documenti18n)
 - [`localizedItem`](#localizedItem)
 - [`defineIcon`](#defineIcon)
+- [Disable creation plugin](#disable-creation-plugin)
 
 ## Pages
 
@@ -489,6 +490,74 @@ export default defineType({
 - `options.list`: Uses the default string option list type of `{title: string, value: string}[]`
 
 The ultility searches for icons within the folder `/icons/select/[icon-value].svg`, if you have a Next.js embbedded setup then store them under `/public/icons/select/[icon-value].svg`.
+
+## Disable creation plugin
+
+Plugin to disable the creation of doucments with the `disableCreation` option set to true. The plugin does this by:
+
+- limiting the document's action to (these options can be overidden):
+  - publish
+  - restore
+  - discard changes
+- removing document type from create button found on the top left of the Studio
+
+### Basic usage
+
+```tsx
+sanity.config.ts;
+
+import { disableCreation } from "@tinloof/sanity-studio";
+import schemas from "@/sanity/schemas";
+
+export default defineConfig({
+  name: "studio",
+  title: "Studio",
+  projectId: "12345678",
+  dataset: "production",
+  schema: {
+    types: schemas,
+  },
+  plugins: [disableCreation({ schemaTypes: schemas })],
+});
+```
+
+```tsx
+/schemas/egilnnosst / home.ts;
+
+import { defineType } from "sanity";
+export default defineType({
+  type: "document",
+  name: "home",
+  fields: [
+    {
+      type: "string",
+      name: "title",
+    },
+  ],
+  options: {
+    disableCreation: true,
+  },
+});
+```
+
+### Parameters
+
+- `schemaTypes`: array of schemas found within your Studio
+- `overrideDocumentActions`: The document actions to override, defaults to publish, discardChanges, restore
+
+### Important notice
+
+When using this plugin, make sure you placing it after the `stucutureTool()`.
+
+```tsx
+plugins: [
+  structureTool(),
+  visionTool(),
+  disableCreation({
+    schemaTypes: schemaTypes as SchemaTypeDefinition[],
+  }),
+],
+```
 
 ## Examples
 

--- a/packages/sanity-studio/package.json
+++ b/packages/sanity-studio/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@sanity/asset-utils": "^1.3.0",
-    "@sanity/document-internationalization": "^3.2.1",
+    "@sanity/document-internationalization": "^3.2.0",
     "@sanity/icons": "^3.5.3",
     "@sanity/image-url": "^1.1.0",
     "@sanity/incompatible-plugin": "^1.0.5",

--- a/packages/sanity-studio/src/plugins/disableCreation/actions.ts
+++ b/packages/sanity-studio/src/plugins/disableCreation/actions.ts
@@ -1,0 +1,29 @@
+import { DocumentActionComponent, DocumentActionsContext } from "sanity";
+
+import { DefaultDocumentActions } from "./types";
+import { getIsCreationDisabledDocument } from "./utils";
+
+const defaultActions: DefaultDocumentActions[] = [
+  "publish",
+  "discardChanges",
+  "restore",
+];
+
+// Disable creation actions for documents that have disableCreation set to true
+export const actions = (
+  prev: DocumentActionComponent[],
+  { schema, schemaType }: DocumentActionsContext,
+  overrideDocumentActions?: DefaultDocumentActions[]
+): DocumentActionComponent[] => {
+  const isCreationDisabled = getIsCreationDisabledDocument(schema, schemaType);
+
+  const documentActions = overrideDocumentActions?.length
+    ? overrideDocumentActions
+    : defaultActions;
+
+  return isCreationDisabled
+    ? prev.filter(({ action }) =>
+        action ? documentActions.includes(action) : true
+      )
+    : prev;
+};

--- a/packages/sanity-studio/src/plugins/disableCreation/index.ts
+++ b/packages/sanity-studio/src/plugins/disableCreation/index.ts
@@ -1,0 +1,53 @@
+import { definePlugin } from "sanity";
+
+import { actions } from "./actions";
+import getTemplates from "./templates";
+import { DisableCreationPluginOptions } from "./types";
+
+/**
+ * The `disableCreation` plugin can be used to disable creation of documents that have disableCreation option set to true.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { disableCreation } from "@tinloof/sanity-studio";
+ * import schemas from "@/sanity/schemas";
+ *
+ * export default defineConfig({
+ *   plugins: [disableCreation({ schemaTypes: schemas })],
+ * });
+ * ```
+ *
+ * ```tsx
+ * import {defineType} from 'sanity'
+ *
+ * export default defineType({
+ *   type: 'document',
+ *   name: 'home',
+ *   fields: [
+ *     {
+ *       type: 'string',
+ *       name: 'title',
+ *     },
+ *   ],
+ *   options: {
+ *     disableCreation: true,
+ *   },
+ * })
+ * ```
+ *
+ * @param schemaTypes - The schema types found in the studio, used to filter out templates that have disableCreation set to true
+ * @param overrideDocumentActions - The document actions to override, defaults to publish, discardChanges, restore
+ */
+export const disableCreation = definePlugin<DisableCreationPluginOptions>(
+  ({ schemaTypes, overrideDocumentActions }) => ({
+    name: "tinloof-sanity-disable-creation",
+    document: {
+      actions: (prev, context) =>
+        actions(prev, context, overrideDocumentActions),
+    },
+    schema: {
+      templates: (templates) => getTemplates(templates, schemaTypes),
+    },
+  })
+);

--- a/packages/sanity-studio/src/plugins/disableCreation/templates.ts
+++ b/packages/sanity-studio/src/plugins/disableCreation/templates.ts
@@ -1,0 +1,14 @@
+import { Template } from "sanity";
+import { SchemaTypeDefinition } from "sanity";
+
+import { getCreationDisabledDocuments } from "./utils";
+
+export default function getTemplates(
+  templates: Template[],
+  schemaTypes: SchemaTypeDefinition[]
+): Template[] {
+  return templates?.filter(
+    (template) =>
+      !getCreationDisabledDocuments(schemaTypes)?.includes(template.schemaType)
+  );
+}

--- a/packages/sanity-studio/src/plugins/disableCreation/types.ts
+++ b/packages/sanity-studio/src/plugins/disableCreation/types.ts
@@ -1,0 +1,18 @@
+import { SchemaTypeDefinition } from "sanity";
+
+export type DisableCreationSchemaOptions = {
+  disableCreation?: boolean;
+};
+
+export type DefaultDocumentActions =
+  | "publish"
+  | "discardChanges"
+  | "restore"
+  | "unpublish"
+  | "delete"
+  | "duplicate";
+
+export type DisableCreationPluginOptions = {
+  schemaTypes: SchemaTypeDefinition[];
+  overrideDocumentActions?: DefaultDocumentActions[];
+};

--- a/packages/sanity-studio/src/plugins/disableCreation/utils.ts
+++ b/packages/sanity-studio/src/plugins/disableCreation/utils.ts
@@ -1,0 +1,30 @@
+import { Schema, SchemaTypeDefinition } from "sanity";
+
+import { DisableCreationSchemaOptions } from "./types";
+
+// Get all documents that have disableCreation set to true
+export function getCreationDisabledDocuments(
+  schema: SchemaTypeDefinition[]
+): string[] | undefined {
+  return schema
+    ?.filter(
+      ({ options }) =>
+        (options as DisableCreationSchemaOptions)?.disableCreation
+    )
+    .map((s: { name: string }) => s.name);
+}
+
+// Get if a document has disableCreation set to true
+export function getIsCreationDisabledDocument(
+  schema: Schema,
+  schemaType: string
+): boolean {
+  const docSchema = schema._original?.types?.find(
+    ({ name }) => name === schemaType
+  );
+
+  return (
+    (docSchema?.options as DisableCreationSchemaOptions)?.disableCreation ??
+    false
+  );
+}

--- a/packages/sanity-studio/src/plugins/index.ts
+++ b/packages/sanity-studio/src/plugins/index.ts
@@ -1,2 +1,3 @@
+export * from "./disableCreation";
 export * from "./i18n";
 export * from "./navigator";


### PR DESCRIPTION
Adds the disable creation plugin which disables the creation of documents when the option `disableCreation` is set to true

Also downgrades `@sanity/document-internationalization` from 3.2.1. to 3.2.0 in order to fix the following [issue](https://github.com/tinloof/sanity-kit/issues/112). Another [issue ](https://github.com/sanity-io/document-internationalization/issues/199) was open on the `@sanity/document-internationalization` repo too.