### PR TITLE
Remove query and variables from deps

### DIFF
--- a/.changeset/loud-horses-rush.md
+++ b/.changeset/loud-horses-rush.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": patch
+---
+
+Navigator hotfix

--- a/packages/sanity-studio/src/plugins/navigator/utils/index.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/utils/index.tsx
@@ -25,8 +25,9 @@ export const useSanityFetch = ({
         documentStore.listenQuery(query, variables, {
           perspective: "previewDrafts",
         }),
-      [documentStore, query, variables],
-    ),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [documentStore]
+    )
   );
 
   const loading = subscribe === undefined;
@@ -155,7 +156,7 @@ export function createPageTemplates(creatablePages: NormalizedCreatablePage[]) {
 }
 
 export function normalizeCreatablePages(
-  creatablePageTypes: PagesNavigatorPluginOptions["creatablePages"],
+  creatablePageTypes: PagesNavigatorPluginOptions["creatablePages"]
 ): NormalizedCreatablePage[] {
   return (
     creatablePageTypes?.map((page) => {


### PR DESCRIPTION
Removed query and variables as deps, they were added in this [PR](https://github.com/tinloof/sanity-kit/commit/003dea9d283591f0ec637e11ec7c5185170e702d#diff-3097fd8ffd357e156f7a0ee7bd66994de46bcced867919e18e8615d44c6c60d7)

With them there the pages navigator on the left where all the pages are listed is stuck in a loading state, removing them and not included like before the referenced PR fixes it