### PR TITLE
Background color option and tailwindcss img styles override

### DIFF
--- a/.changeset/olive-tomatoes-admire.md
+++ b/.changeset/olive-tomatoes-admire.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": patch
+---
+
+Background color option and override tailwindcss img styles

--- a/packages/sanity-studio/README.md
+++ b/packages/sanity-studio/README.md
@@ -481,6 +481,7 @@ export default defineType({
           { title: "Clock", value: "clock" },
         ],
         path: "/icons/select",
+        backgroundColor: "black",
       },
     },
   ],
@@ -491,6 +492,7 @@ export default defineType({
 
 - `options.list`: Uses the default string option list type of `{title: string, value: string}[]`
 - `options.path`: Path where icons are located
+- `options.backgroundColor`: Color value to plug into the CSS style `backgroundColor`. Read [here](https://developer.mozilla.org/en-US/docs/Web/CSS/background-color) for possible values.
 
 ## Disable creation plugin
 

--- a/packages/sanity-studio/src/components/IconSelectComponent.tsx
+++ b/packages/sanity-studio/src/components/IconSelectComponent.tsx
@@ -16,7 +16,6 @@ import { styled } from "styled-components";
 import { IconInputProps, IconOptions } from "../types";
 
 const IconContainer = styled(Box)`
-  background-color: white;
   border-radius: 4px;
   cursor: pointer;
 `;
@@ -72,6 +71,7 @@ export function IconSelectComponent(props: IconInputProps): JSX.Element {
 
   const iconOptions = options as IconOptions | undefined;
 
+  const backgroundColor = iconOptions?.backgroundColor ?? "white";
   const iconList = iconOptions?.list ?? [];
   let iconsPath = iconOptions?.path ?? "";
   // Add / to the end of the path if it's not there
@@ -123,7 +123,11 @@ export function IconSelectComponent(props: IconInputProps): JSX.Element {
             padding={3}
           >
             <Flex align="center" gap={3}>
-              <IconContainer paddingX={2} paddingY={1}>
+              <IconContainer
+                paddingX={2}
+                paddingY={1}
+                style={{ backgroundColor }}
+              >
                 <img
                   alt="icon"
                   style={{
@@ -180,7 +184,11 @@ export function IconSelectComponent(props: IconInputProps): JSX.Element {
                     onClick={() => onIconChange(icon.value)}
                     value={icon.value}
                   >
-                    <BlockVariantCard icon={icon.value} iconsPath={iconsPath} />
+                    <BlockVariantCard
+                      icon={icon.value}
+                      iconsPath={iconsPath}
+                      backgroundColor={backgroundColor}
+                    />
                   </Flex>
                 );
               })}
@@ -193,7 +201,6 @@ export function IconSelectComponent(props: IconInputProps): JSX.Element {
 }
 
 const IconStyles = {
-  background: "white",
   borderRadius: 4,
   cursor: "pointer",
   height: "32px",
@@ -206,16 +213,18 @@ const IconStyles = {
 function BlockVariantCard({
   icon,
   iconsPath,
+  backgroundColor,
 }: {
   icon: string;
   iconsPath: string;
+  backgroundColor: string;
 }) {
   return (
     <BlockVariantCardContainer>
       <img
         className="select-icon"
         src={`${iconsPath}${icon}.svg`}
-        style={IconStyles}
+        style={{ ...IconStyles, backgroundColor }}
       />
       <Text style={{ textAlign: "center" }} size={0}>
         {addSpaceBeforeCapitalLetters(icon)}

--- a/packages/sanity-studio/src/components/IconSelectComponent.tsx
+++ b/packages/sanity-studio/src/components/IconSelectComponent.tsx
@@ -31,6 +31,7 @@ const FlexContainer = styled(Flex)`
 `;
 
 const BlockVariantCardContainer = styled(Card)`
+  box-sizing: content-box;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -208,6 +209,8 @@ const IconStyles = {
   marginBottom: "4px",
   padding: "4px",
   width: "32px",
+  maxWidth: "unset",
+  verticalAlign: "unset",
 };
 
 function BlockVariantCard({

--- a/packages/sanity-studio/src/types.ts
+++ b/packages/sanity-studio/src/types.ts
@@ -222,6 +222,7 @@ export type PathnameInputProps = ObjectFieldProps<SlugValue> & {
 export type IconOptions = {
   list: { title: string; value: string }[];
   path: string;
+  backgroundColor?: string;
 };
 
 export type IconParams = Omit<


### PR DESCRIPTION
Adds background color option to the icon schema in cases of where users have light colored icons which cannot been seen on the current default white background

In cases of the below screenshot where the user has a sanity studio embedded into a Next.js app with tailwindcss the following happens to images. Image container and image styles have been updated to override those styles.
![image](https://github.com/user-attachments/assets/4bf6334a-943e-48a3-a39c-a5799eedc23a)
