### PR TITLE
definePathname uniqueness

### DIFF
--- a/.changeset/six-queens-poke.md
+++ b/.changeset/six-queens-poke.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": patch
+---
+
+definePathname uniqueness check updated

--- a/packages/sanity-studio/src/utils/definePathname.ts
+++ b/packages/sanity-studio/src/utils/definePathname.ts
@@ -45,11 +45,12 @@ async function isUnique(
     draft: `drafts.${id}`,
     published: id,
     slug,
+    // Remove slash from end of slug if it exists
+    // Handle cases where there is a page with /blog but a new page is created with /blog/
     slugWithoutSlash: slug.replace(/\/$/, ""),
     locale: document?.locale ?? null,
   };
   const query = `*[!(_id in [$draft, $published]) && (pathname.current == $slug || pathname.current == $slugWithoutSlash) && locale == $locale]`;
   const result = await client.fetch(query, params);
-  console.log(result);
   return result.length === 0;
 }

--- a/packages/sanity-studio/src/utils/definePathname.ts
+++ b/packages/sanity-studio/src/utils/definePathname.ts
@@ -45,9 +45,11 @@ async function isUnique(
     draft: `drafts.${id}`,
     published: id,
     slug,
+    slugWithoutSlash: slug.replace(/\/$/, ""),
     locale: document?.locale ?? null,
   };
-  const query = `*[!(_id in [$draft, $published]) && pathname.current == $slug && locale == $locale]`;
+  const query = `*[!(_id in [$draft, $published]) && (pathname.current == $slug || pathname.current == $slugWithoutSlash) && locale == $locale]`;
   const result = await client.fetch(query, params);
+  console.log(result);
   return result.length === 0;
 }


### PR DESCRIPTION
Current uniqueness test deems /blog and /blog/ to be two different pages

This caused the blog page on Watershed to crash when someone published a new post with the pathname /blog/ without giving them an error.

/blog/ was there as it was set as the initial value.