### PR TITLE
sanity presentation import fix

### DIFF
--- a/.changeset/twelve-carrots-relate.md
+++ b/.changeset/twelve-carrots-relate.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": patch
+---
+
+Sanity presentation import fix

--- a/packages/sanity-studio/src/plugins/navigator/components/List.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/List.tsx
@@ -9,7 +9,7 @@ import {
 import {
   usePresentationNavigate,
   usePresentationParams,
-} from "@sanity/presentation";
+} from "sanity/presentation";
 import { Badge, Box, Card, Flex, Stack, Text, Tooltip } from "@sanity/ui";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import React, { createElement, useRef } from "react";


### PR DESCRIPTION
https://github.com/tinloof/sanity-kit/releases/tag/%40tinloof%2Fsanity-studio%401.7.4 adds a import bug

Seif added a fix for the pages navigator list component to improve performance and imported various things from @sanity/presentation

In the same package update, Cory updated the Sanity packages around the repo and one of the updates included updating things from sanity/presentation instead of @sanity/presentation