### PR TITLE
initial value over current folder

### DIFF
--- a/.changeset/proud-spies-smoke.md
+++ b/.changeset/proud-spies-smoke.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": patch
+---
+
+Pioritise document initial value over current folder

--- a/packages/sanity-studio/src/plugins/navigator/components/Header.tsx
+++ b/packages/sanity-studio/src/plugins/navigator/components/Header.tsx
@@ -150,12 +150,12 @@ function getPathname({
   currentDir: string;
   initialValue: string | undefined;
 }) {
-  if (currentDir) {
-    return `${currentDir}/`;
+  if (initialValue !== undefined) {
+    return initialValue;
   }
 
-  if (initialValue) {
-    return initialValue;
+  if (currentDir) {
+    return `${currentDir}/`;
   }
 
   return "/";


### PR DESCRIPTION
Currently when creating a document with a pathname intial value set will be override if created within a folder.

Set `getPathname` so it priorityizes the initial value of the schmea