### PR TITLE
[TIN-3312: Global search field in defineDocument]

### DIFF
--- a/.changeset/goofy-snakes-speak.md
+++ b/.changeset/goofy-snakes-speak.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-studio": minor
+---
+
+Add `globalSearch` option to `defineDocument` to control visibility in Sanity's global omnisearch. Defaults to `true`.

--- a/packages/sanity-studio/README.md
+++ b/packages/sanity-studio/README.md
@@ -188,7 +188,6 @@ export default defineDocument({
   type: "document",
   options: {
     disableCreation: true, // Disable document creation
-
     // Field customization with FieldCustomization type
     localized: true, // Show locale field (FieldCustomization)
     orderable: "hidden", // Hide order rank field (FieldCustomization)
@@ -198,6 +197,7 @@ export default defineDocument({
         title: "Tag Name",
         validation: (Rule) => Rule.required(),
       }), // Custom field transformation (FieldCustomization)
+    globalSearch: false, // Hide from Sanity's global omnisearch (defaults to true)
   },
   fields: [
     // Your custom fields

--- a/packages/sanity-studio/src/utils/define-document.ts
+++ b/packages/sanity-studio/src/utils/define-document.ts
@@ -23,6 +23,7 @@ export type DefineDocumentDefinition = Omit<DocumentDefinition, "options"> & {
     orderable?: FieldCustomization<ReturnType<typeof orderRankField>>;
     /** Hide the internal title field */
     internalTitle?: FieldCustomization<typeof internalTitleStringField>;
+    globalSearch?: boolean;
   };
 };
 
@@ -35,6 +36,7 @@ export type DefineDocumentDefinition = Omit<DocumentDefinition, "options"> & {
  * - Locale field for internationalization (when enabled)
  * - Order rank field for document ordering (when enabled)
  * - Proper field groups (content and settings)
+ * - Global search visibility control (enabled by default)
  *
  * @param schema - The document schema configuration
  * @returns A complete Sanity document definition with standard fields
@@ -76,6 +78,7 @@ export default function defineDocument(
     localized = false,
     internalTitle = false,
     orderable = false,
+    globalSearch = true,
     ...restOfOptions
   } = options || {};
 
@@ -123,5 +126,7 @@ export default function defineDocument(
         title: title ?? schema?.title,
       }),
     },
+    // eslint-disable-next-line camelcase
+    __experimental_omnisearch_visibility: globalSearch,
   };
 }

--- a/packages/sanity-studio/src/utils/define-page.ts
+++ b/packages/sanity-studio/src/utils/define-page.ts
@@ -72,6 +72,7 @@ export default function definePage(schema: PageDefinition): DocumentDefinition {
     seo,
     internalTitle,
     orderable,
+    globalSearch,
   } = options || {};
 
   const isPathnameFieldCustomization = (
@@ -173,6 +174,7 @@ export default function definePage(schema: PageDefinition): DocumentDefinition {
       localized,
       orderable,
       internalTitle,
+      globalSearch,
     },
     preview: preview ?? {
       select: {


### PR DESCRIPTION
Works on [TIN-3312: Global search field in defineDocument](https://linear.app/tinloof/issue/TIN-3312/global-search-field-in-definedocument)

Adds option to control whether the document gets shown in the global search