### PR TITLE
fix(deps): update lodash to ^4.17.23 [security]

### DIFF
--- a/.changeset/lodash-security-fix.md
+++ b/.changeset/lodash-security-fix.md
@@ -1,0 +1,6 @@
+---
+"@tinloof/sanity-extends": patch
+"@tinloof/sanity-studio": patch
+---
+
+Update lodash to ^4.17.23 to address security vulnerability

--- a/packages/extends/package.json
+++ b/packages/extends/package.json
@@ -25,7 +25,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"lodash": "^4.17.21"
+		"lodash": "^4.17.23"
 	},
 	"peerDependencies": {
 		"sanity": "^5.12.0"

--- a/packages/sanity-studio/package.json
+++ b/packages/sanity-studio/package.json
@@ -62,7 +62,7 @@
 		"@sanity/util": "^5.12.0",
 		"@tanstack/react-virtual": "^3.13.19",
 		"@tinloof/sanity-web": "workspace:*",
-		"lodash": "^4.17.21",
+		"lodash": "^4.17.23",
 		"nanoid": "^5.1.6",
 		"react-rx": "^4.2.2",
 		"use-debounce": "^10.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -678,8 +678,8 @@ importers:
   packages/extends:
     dependencies:
       lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
+        specifier: ^4.17.23
+        version: 4.17.23
       sanity:
         specifier: ^5.12.0
         version: 5.12.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -840,8 +840,8 @@ importers:
         specifier: workspace:*
         version: link:../sanity-web
       lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
+        specifier: ^4.17.23
+        version: 4.17.23
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
@@ -7138,8 +7138,8 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   log-symbols@2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
@@ -12052,7 +12052,7 @@ snapshots:
       '@rushstack/rig-package': 0.5.3
       '@rushstack/terminal': 0.16.0(@types/node@25.1.0)
       '@rushstack/ts-command-line': 5.0.3(@types/node@25.1.0)
-      lodash: 4.17.21
+      lodash: 4.17.23
       minimatch: 10.0.3
       resolve: 1.22.11
       semver: 7.5.4
@@ -12071,7 +12071,7 @@ snapshots:
       '@rushstack/terminal': 0.19.5(@types/node@24.10.15)
       '@rushstack/ts-command-line': 5.1.5(@types/node@24.10.15)
       diff: 8.0.2
-      lodash: 4.17.21
+      lodash: 4.17.23
       minimatch: 10.0.3
       resolve: 1.22.11
       semver: 7.5.4
@@ -12091,7 +12091,7 @@ snapshots:
       '@rushstack/terminal': 0.19.5(@types/node@25.1.0)
       '@rushstack/ts-command-line': 5.1.5(@types/node@25.1.0)
       diff: 8.0.2
-      lodash: 4.17.21
+      lodash: 4.17.23
       minimatch: 10.0.3
       resolve: 1.22.11
       semver: 7.5.4
@@ -13587,7 +13587,7 @@ snapshots:
   '@sanity/id-utils@1.0.0':
     dependencies:
       '@sanity/uuid': 3.0.2
-      lodash: 4.17.21
+      lodash: 4.17.23
       ts-brand: 0.2.0
 
   '@sanity/image-url@2.0.3':
@@ -13801,7 +13801,7 @@ snapshots:
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/uuid': 3.0.2
       hotscript: 1.0.13
-      lodash: 4.17.21
+      lodash: 4.17.23
       mendoza: 3.0.8
       nanoid: 5.1.6
       rxjs: 7.8.2
@@ -13814,7 +13814,7 @@ snapshots:
       '@sanity/diff-match-patch': 3.2.0
       '@sanity/uuid': 3.0.2
       hotscript: 1.0.13
-      lodash: 4.17.21
+      lodash: 4.17.23
       mendoza: 3.0.8
       nanoid: 5.1.6
       rxjs: 7.8.2
@@ -14206,7 +14206,7 @@ snapshots:
 
   '@sanity/telemetry@0.8.1(react@19.2.4)':
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.17.23
       react: 19.2.4
       rxjs: 7.8.2
       typeid-js: 0.3.0
@@ -15114,7 +15114,7 @@ snapshots:
       graceful-fs: 4.2.11
       is-stream: 2.0.1
       lazystream: 1.0.1
-      lodash: 4.17.21
+      lodash: 4.17.23
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
@@ -15536,7 +15536,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       date-fns: 2.30.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       rxjs: 7.8.2
       shell-quote: 1.8.3
       spawn-command: 0.0.2
@@ -16900,7 +16900,7 @@ snapshots:
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
@@ -17332,7 +17332,7 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   log-symbols@2.2.0:
     dependencies:
@@ -19219,7 +19219,7 @@ snapshots:
       '@sanity/language-filter': 4.0.6(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(sanity@5.12.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@sanity/ui': 3.1.13(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.4)(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       fast-deep-equal: 3.1.3
-      lodash: 4.17.21
+      lodash: 4.17.23
       react: 19.2.4
       sanity: 5.12.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@types/node@25.1.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(babel-plugin-react-compiler@1.0.0)(jiti@2.6.1)(lightningcss@1.31.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.44.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       styled-components: 6.3.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary
- Updates `lodash` from `^4.17.21` to `^4.17.23` in `packages/extends` and `packages/sanity-studio`
- Addresses security vulnerability in lodash 4.17.21
- Updates `package.json` files directly (not just lockfile) to ensure the fix is enforced

## Notes
This replaces the Renovate PR which only updated the lockfile. Updating the `package.json` ensures the security fix is explicitly required.

## Test plan
- [x] `pnpm install` completes successfully
- [x] `pnpm test` passes (93 tests)