### PR TITLE
chore: release @tinloof/sanity-media

### DIFF
--- a/.changeset/release-sanity-media.md
+++ b/.changeset/release-sanity-media.md
@@ -1,0 +1,5 @@
+---
+"@tinloof/sanity-media": minor
+---
+
+First stable release of the Sanity media plugin: media library tool with S3-compatible storage adapters (AWS S3, Cloudflare R2), image/video/file inputs, drag & drop uploads, tagging, metadata editing, video thumbnails, and video caption support.


### PR DESCRIPTION
Changeset-only PR to trigger the first stable release of `@tinloof/sanity-media` (minor → 0.1.0), following the merge of #243.

Once merged, the changesets release action will open/refresh the `[ci] release` PR that publishes the package.